### PR TITLE
issue 64 - adding links to translations by google and bing

### DIFF
--- a/web/classes/Transvision/ShowResults.php
+++ b/web/classes/Transvision/ShowResults.php
@@ -171,14 +171,19 @@ class ShowResults
 
                   <td dir='{$direction1}'>
                     <div class='string'>
-                      <a href='http://translate.google.com/#{$locale1ShortCode}/{$locale2ShortCode}/"
-                      . urlencode(strip_tags($sourceString))
-                      . "'>{$sourceString}</a>
+                      {$sourceString}
                     </div>
                     <div dir='ltr' class='infos'>
                       <a class='source_link' href='{$locale1Path}'>
                         &lt;source&gt;
                       </a>
+                      <span>Translate with:</span>
+                      <a href='http://translate.google.com/#{$locale1ShortCode}/{$locale2ShortCode}/"
+                      . urlencode(strip_tags($sourceString))
+                      . "' target='_blank'>Google</a>
+                      <a href='http://www.bing.com/translator/?from={$locale1ShortCode}&to={$locale2ShortCode}&text="
+                      . urlencode(strip_tags($sourceString))
+                      . "' target='_blank'>BING</a>
                     </div>
                   </td>
 

--- a/web/style/new_glossary.css
+++ b/web/style/new_glossary.css
@@ -179,7 +179,7 @@ td div.infos {
     text-align:right;
     margin-top:4px;
 }
-td div.infos a {
+td div.infos a, td div.infos span {
     float:left;
     margin-right: 5px;
 }


### PR DESCRIPTION
Related to issues https://github.com/mozfr/transvision/issues/13 and https://github.com/mozfr/transvision/issues/64

Now, we offer the google translation as a link and not as a link in the string. I've added also the possibility to translate the string through BING
