### PR TITLE
issue 77 - bugzilla_components.txt created in wrong folder

### DIFF
--- a/web/cache/.gitignore
+++ b/web/cache/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/web/classes/Transvision/Bugzilla.php
+++ b/web/classes/Transvision/Bugzilla.php
@@ -11,8 +11,8 @@ class Bugzilla
      */
     public static function getBugzillaComponents()
     {
-        $cache_file = 'bugzilla_components.txt';
-        if (!file_exists($cache_file) || filemtime('bugzilla_components.txt') + (4 * 7 * 24 * 60 * 60) < time() ) {
+        $cache_file = CACHE . 'bugzilla_components.json';
+        if (!file_exists($cache_file) || filemtime($cache_file) + (4 * 7 * 24 * 60 * 60) < time() ) {
             $json_url = 'https://bugzilla.mozilla.org/jsonrpc.cgi?method=Product.get&params=[%20{%20%22names%22:%20[%22Mozilla%20Localizations%22]}%20]';
             file_put_contents($cache_file, file_get_contents($json_url));
         }

--- a/web/inc/constants.php
+++ b/web/inc/constants.php
@@ -11,6 +11,7 @@ define('INSTALLROOT', $ini_array['install'] . '/');
 define('WEBROOT', INSTALLROOT . 'web/');
 define('INC', INSTALLROOT . 'web/inc/');
 define('VIEWS', INSTALLROOT . 'web/views/');
+define('CACHE', INSTALLROOT . 'web/cache/');
 
 // Special modes for the app
 define('DEBUG', (strstr(VERSION, 'dev') || isset($_GET['debug'])) ? true : false);


### PR DESCRIPTION
https://github.com/mozfr/transvision/issues/77

I've created a "cache" folder (with a .gitignore file to ignore all the files inside it in git) and I've define CACHE to point to this folder in "constants.php" (maybe this is not a good idea?). 

"bugzilla_components.txt" renamed to "bugzilla_components.json" (I think it makes more sense).
