### PR TITLE
Remove extra </a> when reporting a bug

### DIFF
--- a/web/classes/Transvision/ShowResults.php
+++ b/web/classes/Transvision/ShowResults.php
@@ -114,7 +114,7 @@ class ShowResults
             $targetString = trim($strings[1]);
 
             // Link to entity
-            $entityLink = "?sourcelocale={$locale1}&locale={$locale2}&repo={$searchOptions['repo']}&search_type=entities&recherche={$key}</a>";
+            $entityLink = "?sourcelocale={$locale1}&locale={$locale2}&repo={$searchOptions['repo']}&search_type=entities&recherche={$key}";
 
             // Bugzilla GET data
             $bugSummary = rawurlencode("Translation update proposed for ${key}");


### PR DESCRIPTION
See for example https://bugzilla.mozilla.org/show_bug.cgi?id=884672

When reporting a bug, the final link has an extra final </a>
