### PR TITLE
Gaia Spanish TMX not on download page

### DIFF
--- a/web/views/downloads.php
+++ b/web/views/downloads.php
@@ -28,7 +28,7 @@ echo '<table id="DownloadsTable">
 
 // Table content
 $loc_list = array();
-$locales = array("central/", "gaia/", "aurora/", "beta/", "release/");
+$locales = array('central/', 'gaia/', 'aurora/', 'beta/', 'release/');
 foreach ($locales as $loc) {
     $loc_list = array_merge($loc_list, Utils::getFilenamesInFolder(TMX . $loc));
 }


### PR DESCRIPTION
https://github.com/mozfr/transvision/issues/91

Changed to take the "locales" from central and gaia and merge (and order) them in an array to create the table. 

Maybe we should include all the other repositories? all "browser locales" are included into central ?
