### PR TITLE
Make the current search context more evident

### DIFF
--- a/web/style/new_glossary.css
+++ b/web/style/new_glossary.css
@@ -283,6 +283,11 @@ fieldset#main select {
     width: 110px;
 }
 
+fieldset#main select#search_type {
+    display: block;
+    width: 140px;
+}
+
 fieldset#main #search {
     margin: 0;
 }
@@ -300,6 +305,16 @@ fieldset#main #search input[type=text] {
     padding: 5px 7px;
     transition: all 0.1s linear 0s;
     width: 80%;
+}
+
+fieldset#main #searchcontext {
+    font-size: 0.8em;
+    margin-top: 2px;
+    padding-left: 9px;
+}
+
+fieldset#main #searchcontext span {
+    font-weight: bold;
 }
 
 #root fieldset#main fieldset {

--- a/web/views/search_form.php
+++ b/web/views/search_form.php
@@ -22,8 +22,9 @@ foreach ($repositories as $repository) {
 }
 
 // Build the search type switcher
+$search_type_descriptions = array('strings' => 'Strings', 'entities'=> 'Entities', 'strings_entities' => 'Strings & Entities');
 $search_type_list = Utils::getHtmlSelectOptions(
-    array('strings' => 'Strings', 'entities'=> 'Entities', 'strings_entities' => 'Strings & Entities'),
+    $search_type_descriptions, 
     $check['search_type'],
     true
 );
@@ -103,7 +104,7 @@ if (in_array($cookieTargetLocale, $loc_list[$check['repo']])) {
             </fieldset>
             <fieldset>
                 <legend>Search in</legend>
-                <select name='search_type'>
+                <select name='search_type' id='search_type' onchange="changeSearchContext(this);">
                 <?=$search_type_list?>
                 </select>
             </fieldset>
@@ -155,6 +156,7 @@ if (in_array($cookieTargetLocale, $loc_list[$check['repo']])) {
             <div id="search">
                 <input type="text" name="recherche" id="recherche" value="<?=$initial_search?>" placeholder="Type your search here" size="30" />
                 <input type="submit" value="Search" alt="Search" />
+                <p id="searchcontext">Search will be performed on: <span id="searchcontextvalue"><?=$search_type_descriptions[$check['search_type']]?></span>.</p>
             </div>
         </fieldset>
  </form>
@@ -225,6 +227,10 @@ foreach ($repositories as $repository) {
     changeDefaultSource('target_locale');
 
     changeDefaultSource('repository');
+}
+//Change the label below the search field to reflect the value of "Search in"
+function changeSearchContext(element) {
+    document.getElementById('searchcontextvalue').innerHTML = element.options[element.selectedIndex].text;
 }
 //Focus on the search field
 window.onload = function() {


### PR DESCRIPTION
Fix: make the "Search in" select larger, currently it can't display "Strings & Entities" correctly

Enhancements (fix issue #107):
- Add a label under the search field explaining where the search will be performed
- Label changes according to the select
