### PR TITLE
remove duplicate code, turn getTMXResults into a static method

### DIFF
--- a/web/classes/Transvision/Bugzilla.php
+++ b/web/classes/Transvision/Bugzilla.php
@@ -31,17 +31,17 @@ class Bugzilla
      * @param $components_array array
      * @return $component_string
      */
-    public static function collectLanguageComponent($actual_lng, $components_array)
+    public static function collectLanguageComponent($actual_lang, $components_array)
     {
-        $actual_lng = ($actual_lng == 'es') ? 'es-ES' : $actual_lng;
-        $actual_lng = ($actual_lng == 'pa') ? 'pa-IN' : $actual_lng;
-        $actual_lng = Bugzilla::bugzillaLocaleCode($actual_lng);
+        $actual_lang = ($actual_lang == 'es') ? 'es-ES' : $actual_lang;
+        $actual_lang = ($actual_lang == 'pa') ? 'pa-IN' : $actual_lang;
+        $actual_lang = Bugzilla::bugzillaLocaleCode($actual_lang);
 
         $component_string = 'Other';
-        $actual_lng = $actual_lng . ' /';
+        $actual_lang = $actual_lang . ' /';
 
         foreach ($components_array as $component) {
-            if (Strings::startsWith($component['name'], $actual_lng)) {
+            if (Strings::startsWith($component['name'], $actual_lang)) {
                 $component_string = $component['name'];
                 break;
             }

--- a/web/classes/Transvision/Utils.php
+++ b/web/classes/Transvision/Utils.php
@@ -50,18 +50,18 @@ class Utils
      *
      * @param  string $option
      * @param  string $cookie
-     * @return string $defaultChecked -> ' checked="checked"' or false
+     * @return string $default_checked -> ' checked="checked"' or false
      */
 
     public static function checkboxDefaultOption($option, $cookie)
     {
         if ($cookie == $option) {
-            $defaultChecked = ' checked="checked"';
+            $default_checked = ' checked="checked"';
         } else {
-            $defaultChecked = false;
+            $default_checked = false;
         }
 
-        return $defaultChecked;
+        return $default_checked;
     }
 
     /*
@@ -79,24 +79,6 @@ class Utils
         }
 
         return ($str) ? ' checked="checked"' : '';
-    }
-
-    /*
-     * Create an array for search results with this format:
-     * 'entity' => ['locale 1', 'locale 2']
-     */
-
-    public static function results($entities, $locale1Strings, $locale2Strings)
-    {
-
-        $searchResults = array();
-
-        foreach ($entities as $entity) {
-            $searchResults[$entity] = array($locale1Strings[$entity],
-                                             $locale2Strings[$entity]);
-        }
-
-        return $searchResults;
     }
 
     public static function markString($needle, $haystack)
@@ -272,15 +254,15 @@ class Utils
      *
      * @param array  $options  list of <option>
      * @param string $selected the option which should have the 'selected' html attribute
-     * @nicelabels  boolean $nicelabels, indicates if $options is an associative array
+     * @nice_labels  boolean $nice_labels, indicates if $options is an associative array
      *                      with the array value as the text inside the <option> tag
      * @return string
      */
-    public static function getHtmlSelectOptions($options, $selected, $nicelabels = false)
+    public static function getHtmlSelectOptions($options, $selected, $nice_labels = false)
     {
         $html = '';
         foreach ($options as $key => $option) {
-            $value = ($nicelabels) ? $key : $option;
+            $value = ($nice_labels) ? $key : $option;
             $ch = ($value == $selected) ? ' selected' : '';
             $html.= "<option" . $ch . " value=" . $value . ">" . $option . "</option>";
         }
@@ -292,14 +274,14 @@ class Utils
      * Return the list of files in a folder as an array
      *
      * @param  string $folder  the directory we want to access
-     * @param  array  $exclude files to exclude from results, by default . and ..
+     * @param  array  $excluded_files to exclude from results, by default . and ..
      * @return array
      */
-    public static function getFilenamesInFolder($folder, $excludedFiles = array('.', '..', '.htaccess'))
+    public static function getFilenamesInFolder($folder, $excluded_files = array('.', '..', '.htaccess'))
     {
         // Get the locale list
         $files = scandir($folder);
-        $files = array_diff($files, $excludedFiles);
+        $files = array_diff($files, $excluded_files);
 
         return $files;
     }
@@ -328,12 +310,12 @@ class Utils
 
         // We have only one Spanish for Gaia
         if (in_array($locale, $spanishes)) {
-            $gaialocale = 'es';
+            $gaia_locale = 'es';
         } else {
-            $gaialocale = $locale;
+            $gaia_locale = $locale;
         }
 
-        $file = TMX . $repository . '/' . $gaialocale . '/cache_' . $gaialocale . '.php';
+        $file = TMX . $repository . '/' . $gaia_locale . '/cache_' . $gaia_locale . '.php';
 
         if (file_exists($file)) {
             include $file;
@@ -359,11 +341,11 @@ class Utils
     }
 
     /*
-     * Compare original and translated strings to check anormal length
+     * Compare original and translated strings to check abnormal length
      *
      * @param $origin en-US string
      * @param $translated locale string
-     * @return $anormal_length
+     * @return $abnormal_length
      */
     public static function checkAbnormalStringLength($origin, $translated)
     {
@@ -376,26 +358,26 @@ class Utils
 
             if ($origin_length > 100 && $difference > 150) {
                 //large translation for a large origin
-                $anormal_length =  'large';
+                $abnormal_length =  'large';
             } elseif ($origin_length > 100 && $difference < 50) {
                 //small translation for a large origin
-                $anormal_length =  'small';
+                $abnormal_length =  'small';
             } elseif ($origin_length < 100 && $difference > 200 && $translated_length > 100) {
                 //large translation for a small origin
-                $anormal_length =  'large';
+                $abnormal_length =  'large';
             } elseif ($origin_length < 100 && $difference < 25) {
                 //small translation for a small origin
-                $anormal_length =  'small';
+                $abnormal_length =  'small';
             } else {
                 //no problems detected
-                $anormal_length =  false;
+                $abnormal_length =  false;
             }
         } else {
             //missing origin or translated string
-            $anormal_length =  false;
+            $abnormal_length =  false;
         }
 
-        return $anormal_length;
+        return $abnormal_length;
     }
 
     /*

--- a/web/classes/Transvision/VersionControl.php
+++ b/web/classes/Transvision/VersionControl.php
@@ -18,7 +18,7 @@ class VersionControl
         $path          = explode(':', $path);
         $path          = $path[0];
         $path          = explode('/', $path);
-        $entityFile   = array_pop($path);
+        $entity_file   = array_pop($path);
         $path          = implode('/', $path);
         $exploded_path = explode('/', $path);
         $base_folder   = $exploded_path[0];
@@ -40,7 +40,7 @@ class VersionControl
                 $url .= '/gaia-l10n/' . $locale . '/file/default/';
             }
 
-            return $url . $path . '/' . $entityFile;
+            return $url . $path . '/' . $entity_file;
         }
 
         $en_US_Folder_Mess = array(
@@ -125,11 +125,11 @@ class VersionControl
 
             if ($loop == true) {
                 $path = explode('/', $path);
-                $categorie = array_shift($path);
-                $path = $categorie . '/locales/en-US/' . implode('/', $path);
+                $category = array_shift($path);
+                $path = $category . '/locales/en-US/' . implode('/', $path);
             }
         }
 
-        return $url . $path . '/' . $entityFile;
+        return $url . $path . '/' . $entity_file;
     }
 }

--- a/web/inc/l10n-init.php
+++ b/web/inc/l10n-init.php
@@ -4,30 +4,30 @@
  */
 
 if (isset($_GET['repo']) && in_array($_GET['repo'], $repos)) {
-    $allLocales = file(INSTALLROOT . '/' . $_GET['repo'] . '.txt', FILE_IGNORE_NEW_LINES);
+    $all_locales = file(INSTALLROOT . '/' . $_GET['repo'] . '.txt', FILE_IGNORE_NEW_LINES);
 } else {
-    $allLocales = file(INSTALLROOT . '/central.txt', FILE_IGNORE_NEW_LINES);
+    $all_locales = file(INSTALLROOT . '/central.txt', FILE_IGNORE_NEW_LINES);
 }
 
-$allLocales[] = 'en-US'; // Add en-US as a regular locale without impacting glossaire.sh
+$all_locales[] = 'en-US'; // Add en-US as a regular locale without impacting glossaire.sh
 
 // Don't try to guess locales with the Json API as it is used by scripts, not humans
 if (WEBSERVICE) {
     $locale = isset($_GET['locale'])
               ? $_GET['locale']
               : '';
-    $sourceLocale = isset($_GET['sourcelocale'])
+    $source_locale = isset($_GET['sourcelocale'])
                     ? $_GET['sourcelocale']
                     : '';
 
     return;
 }
 
-$l10n = new tinyl10n\ChooseLocale($allLocales);
+$l10n = new tinyl10n\ChooseLocale($all_locales);
 $l10n->setDefaultLocale('fr');
 $l10n->mapLonglocales = true;
 $locale = $l10n->getCompatibleLocale();
-$sourceLocale = 'en-US';
+$source_locale = 'en-US';
 
 // Bypass locale & source locale detection if there are a COOKIES stored with them
 
@@ -35,22 +35,22 @@ if (isset($_COOKIE['default_target_locale'])) {
     $locale = $_COOKIE['default_target_locale'];
 }
 if (isset($_COOKIE['default_source_locale'])) {
-    $sourceLocale = $_COOKIE['default_source_locale'];
+    $source_locale = $_COOKIE['default_source_locale'];
 }
 
 // Bypass locale detection if the page sends a valid GET variable
-if (isset($_GET['locale']) && in_array($_GET['locale'], $allLocales)) {
+if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
     $l10n->setDefaultLocale($_GET['locale']);
     $locale = $l10n->getDefaultLocale();
 }
 
 // Bypass default source locale for locale to locale comparison
 if (isset($_GET['sourcelocale']) && $_GET['sourcelocale'] == 'en-US') {
-    $sourceLocale = 'en-US';
-} elseif (isset($_GET['sourcelocale']) && in_array($_GET['sourcelocale'], $allLocales)) {
-    $sourceLocale = $_GET['sourcelocale'];
+    $source_locale = 'en-US';
+} elseif (isset($_GET['sourcelocale']) && in_array($_GET['sourcelocale'], $all_locales)) {
+    $source_locale = $_GET['sourcelocale'];
 }
 
 // Get rtl attribute for source and target locales
-$localeDir = $l10n->getDirection($locale);
-$sourceLocaleDir = $l10n->getDirection($sourceLocale);
+$locale_dir = $l10n->getDirection($locale);
+$source_locale_dir = $l10n->getDirection($source_locale);

--- a/web/inc/recherche.php
+++ b/web/inc/recherche.php
@@ -2,12 +2,12 @@
 namespace Transvision;
 
 // Include all strings
-$tmx_source = Utils::getRepoStrings($sourceLocale, $check['repo']);
+$tmx_source = Utils::getRepoStrings($source_locale, $check['repo']);
 $tmx_target = Utils::getRepoStrings($locale, $check['repo']);
 
 // Regex options
-$whole_word     = ($check['whole_word']) ? '\b' : '';
-$case_sensitive = ($check['case_sensitive']) ? '' : 'i';
+$whole_word     = $check['whole_word']     ? '\b' : '';
+$case_sensitive = $check['case_sensitive'] ? '' : 'i';
 
 $regex = '/' . $whole_word . $my_search . $whole_word . '/' . $case_sensitive;
 $entities = preg_grep($regex, array_keys($tmx_source));

--- a/web/inc/urls.php
+++ b/web/inc/urls.php
@@ -16,4 +16,5 @@ $urls = array(
     'showrepos'         => 'showrepos',
     'gaia'              => 'gaia',
     'variables'         => 'checkvariables',
+    '3locales'          => '3locales',
 );

--- a/web/tests/units/Transvision/ShowResults.php
+++ b/web/tests/units/Transvision/ShowResults.php
@@ -6,7 +6,7 @@ use atoum;
 
 class ShowResults extends atoum\test
 {
-    public function formatEntityDataProvider()
+    public function formatEntityDP()
     {
         return array(
             array('browser/chrome/browser/browser.dtd:historyHomeCmd.label', false)
@@ -14,7 +14,7 @@ class ShowResults extends atoum\test
     }
 
     /**
-     * @dataProvider formatEntityDataProvider
+     * @dataProvider formatEntityDP
      */
     public function testFormatEntity($a, $b)
     {
@@ -22,6 +22,39 @@ class ShowResults extends atoum\test
         $this
             ->string($obj->formatEntity($a, $b))
                 ->isEqualTo('<span class="green">browser</span><span class="superset">&nbsp;&sup;&nbsp;</span>chrome<span class="superset">&nbsp;&sup;&nbsp;</span>browser<span class="superset">&nbsp;&sup;&nbsp;</span>browser.dtd<br><span class="red">historyHomeCmd.label</span>')
+        ;
+    }
+
+    public function getStringFromEntityDP()
+    {
+        return array(
+            array(
+                'browser/pdfviewer/viewer.properties:last_page.label',
+                ['browser/pdfviewer/viewer.properties:last_page.label' => 'Aller à la dernière page'],
+                'Aller à la dernière page'
+                ),
+            array(
+                'browser/pdfviewer/viewer.properties:last_page.label',
+                ['entity.is.not.found' => 'Aller à la dernière page'],
+                false
+                ),
+            array(
+                'browser/pdfviewer/viewer.properties:last_page.label',
+                ['browser/pdfviewer/viewer.properties:last_page.label' => ''],
+                false
+                ),
+        );
+    }
+
+    /**
+     * @dataProvider getStringFromEntityDP
+     */
+    public function testGetStringFromEntity($a, $b, $c)
+    {
+        $obj = new \Transvision\ShowResults();
+        $this
+            ->variable($obj->getStringFromEntity($a, $b))
+                ->isIdenticalTo($c)
         ;
     }
 

--- a/web/views/accesskeys.php
+++ b/web/views/accesskeys.php
@@ -4,7 +4,7 @@ namespace Transvision;
 require_once WEBROOT . 'inc/l10n-init.php';
 
 // let's add en-US to check their errors too
-$allLocales[] = 'en-US';
+$all_locales[] = 'en-US';
 
 $repo = 'central';
 
@@ -12,12 +12,12 @@ if (isset($_GET['repo']) && in_array($_GET['repo'], $desktop_repos)) {
     $repo = $_GET['repo'];
 }
 
-if (isset($_GET['locale']) && in_array($_GET['locale'], $allLocales)) {
+if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
     $locale = $_GET['locale'];
 }
 
 $strings[$repo]        = Utils::getRepoStrings($locale, $repo);
-$stringsEnglish[$repo] = Utils::getRepoStrings('en-US', $repo);
+$strings_english[$repo] = Utils::getRepoStrings('en-US', $repo);
 
 $channel_selector = Utils::getHtmlSelectOptions(
     array_intersect_key(
@@ -57,8 +57,8 @@ foreach ($akeys as $akey) {
     foreach ($ak_labels as $ak_label) {
         if (isset($strings[$repo][$entity . $ak_label])
              && !empty($strings[$repo][$entity . $ak_label])
-             && isset($stringsEnglish[$repo][$akey])
-             && !empty($stringsEnglish[$repo][$akey])
+             && isset($strings_english[$repo][$akey])
+             && !empty($strings_english[$repo][$akey])
             ) {
             if ($akey_value == '') {
                 $ak_results[$akey] = $entity . $ak_label;

--- a/web/views/channelcomparison.php
+++ b/web/views/channelcomparison.php
@@ -14,7 +14,7 @@ if (isset($_GET['chan2']) && in_array($_GET['chan2'], $desktop_repos)) {
     $chan2 = $_GET['chan2'];
 }
 
-if (isset($_GET['locale']) && in_array($_GET['locale'], $allLocales)) {
+if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
     $locale = $_GET['locale'];
 }
 
@@ -22,13 +22,13 @@ $strings = array();
 $strings[$chan1] = Utils::getRepoStrings($locale, $chan1);
 $strings[$chan2] = Utils::getRepoStrings($locale, $chan2);
 
-$chanSelector1 = $chanSelector2 = '';
+$chan_selector1 = $chan_selector2 = '';
 
 foreach ($desktop_repos as $repo) {
     $ch1 = ($repo == $chan1) ? ' selected' : '';
     $ch2 = ($repo == $chan2) ? ' selected' : '';
-    $chanSelector1 .= "\t<option" . $ch1 . " value=" . $repo . ">" .$repos_nice_names[$repo] . "</option>\n";
-    $chanSelector2 .= "\t<option" . $ch2 . " value=" . $repo . ">" .$repos_nice_names[$repo] . "</option>\n";
+    $chan_selector1 .= "\t<option" . $ch1 . " value=" . $repo . ">" .$repos_nice_names[$repo] . "</option>\n";
+    $chan_selector2 .= "\t<option" . $ch2 . " value=" . $repo . ">" .$repos_nice_names[$repo] . "</option>\n";
 }
 
 // Get the locale list
@@ -57,13 +57,13 @@ $temp = array_diff($temp, $strings[$chan2]);
             <fieldset>
                 <legend>Channel 1:</legend>
                 <select name='chan1'>
-                <?=$chanSelector1?>
+                <?=$chan_selector1?>
                 </select>
             </fieldset>
             <fieldset>
                 <legend>Channel 2:</legend>
                 <select name='chan2'>
-                <?=$chanSelector2?>
+                <?=$chan_selector2?>
                 </select>
             </fieldset>
             <input type="submit" value="Go" alt="Go" />

--- a/web/views/checkvariables.php
+++ b/web/views/checkvariables.php
@@ -5,10 +5,10 @@ require_once WEBROOT . 'inc/l10n-init.php';
 
 if (isset($_GET['repo']) && in_array($_GET['repo'], $repos)) {
     $repo = $_GET['repo'];
-    $allLocales = file(INSTALLROOT . '/' . $_GET['repo'] . '.txt', FILE_IGNORE_NEW_LINES);
+    $all_locales = file(INSTALLROOT . '/' . $_GET['repo'] . '.txt', FILE_IGNORE_NEW_LINES);
 } else {
     $repo = 'central';
-    $allLocales = file(INSTALLROOT . '/central.txt', FILE_IGNORE_NEW_LINES);
+    $all_locales = file(INSTALLROOT . '/central.txt', FILE_IGNORE_NEW_LINES);
 }
 
 if (isset($_GET['locale'])) {
@@ -20,7 +20,7 @@ if (isset($_GET['locale'])) {
         if ($_GET['locale'] == 'sr') {
             $locale = 'sr-Cyrl';
         }
-    } elseif (in_array($_GET['locale'], $allLocales)) {
+    } elseif (in_array($_GET['locale'], $all_locales)) {
         $locale = $_GET['locale'];
     }
 }
@@ -47,7 +47,7 @@ include __DIR__ . '/simplesearchform.php';
 
 // rtl support
 $rtl = array('ar', 'fa', 'he');
-$direction1 = (in_array($sourceLocale, $rtl)) ? 'rtl' : 'ltr';
+$direction1 = (in_array($source_locale, $rtl)) ? 'rtl' : 'ltr';
 $direction2 = (in_array($locale, $rtl)) ? 'rtl' : 'ltr';
 
 $source = array_map(['Transvision\AnalyseStrings', 'cleanUpEntities'], $source);
@@ -66,7 +66,7 @@ if (Strings::startsWith($repo, 'gaia')) {
 $mismatch = AnalyseStrings::differences($source, $target, $regex_pattern);
 
 // Get cached bugzilla components (languages list) or connect to Bugzilla API to retrieve them
-$bugzillaComponent = rawurlencode(
+$bugzilla_component = rawurlencode(
     Bugzilla::collectLanguageComponent(
         $locale,
         Bugzilla::getBugzillaComponents()
@@ -74,7 +74,7 @@ $bugzillaComponent = rawurlencode(
 );
 
 $bugzilla_link = 'https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&component='
-               . $bugzillaComponent
+               . $bugzilla_component
                . '&product=Mozilla%20Localizations&status_whiteboard=%5Btransvision-feedback%5D';
 
 

--- a/web/views/downloads.php
+++ b/web/views/downloads.php
@@ -2,18 +2,18 @@
 namespace Transvision;
 
 // Compute Download table content
-$downloadTable = function() {
-    $localesList = array();
+$download_table = function() {
+    $locales_list = array();
 
     foreach (Utils::getFilenamesInFolder(TMX) as $locale) {
-        $localesList = array_merge($localesList, Utils::getFilenamesInFolder(TMX . $locale . '/'));
+        $locales_list = array_merge($locales_list, Utils::getFilenamesInFolder(TMX . $locale . '/'));
     }
 
     // Clean up table to remove duplicate and sort by locale name
-    $localesList = array_unique($localesList);
-    sort($localesList);
+    $locales_list = array_unique($locales_list);
+    sort($locales_list);
 
-    return Utils::tmxDownloadTable($localesList);
+    return Utils::tmxDownloadTable($locales_list);
 };
 
-print $downloadTable();
+print $download_table();

--- a/web/views/gaia.php
+++ b/web/views/gaia.php
@@ -4,8 +4,8 @@ namespace Transvision;
 require_once WEBROOT .'inc/l10n-init.php';
 
 // Serbian hack
-$allLocales[] = 'sr-Cyrl';
-$allLocales[] = 'sr-Latn';
+$all_locales[] = 'sr-Cyrl';
+$all_locales[] = 'sr-Latn';
 
 //~ error_log(print_r($repos,1));
 
@@ -15,7 +15,7 @@ $get_or_set = function($arr, $value, $fallback) {
             : $fallback;
 };
 
-$locale = $get_or_set($allLocales, 'locale', $locale);
+$locale = $get_or_set($all_locales, 'locale', $locale);
 
 $get_repo_strings = function($locale, $repo) {
     return array_filter(Utils::getRepoStrings($locale, $repo), 'strlen');
@@ -77,7 +77,7 @@ print "<h2>$locale</h2>";
 print $table('How many strings are translated?', ['repo', $locale, 'en-US'], $status, 'hihi');
 
 
-$table5col = function ($table_title, $column_titles, $strings, $anchor) use ($locale) {
+$table_5_col = function ($table_title, $column_titles, $strings, $anchor) use ($locale) {
 
     $english_gaia_keys    = array_fill_keys(array_keys($strings['gaia-en-US']), '');
     $english_gaia1_1_keys = array_fill_keys(array_keys($strings['gaia_1_1-en-US']), '');
@@ -140,7 +140,7 @@ $table5col = function ($table_title, $column_titles, $strings, $anchor) use ($lo
     return $table;
 };
 
-print $table5col(
+print $table_5_col(
     'diverging translations across repositories',
     ['Key',
      $repos_nice_names['gaia'],
@@ -178,7 +178,7 @@ $table .= '</table>';
 
 print $table;
 
-$table3col = function($table_title, $column_titles, $strings, $anchor) use ($locale) {
+$table_3_col = function($table_title, $column_titles, $strings, $anchor) use ($locale) {
     $strings = array_values($strings);
     $temp = array_diff_key($strings[5], $strings[4]);
 
@@ -213,7 +213,7 @@ $table3col = function($table_title, $column_titles, $strings, $anchor) use ($loc
 };
 
 
-print $table3col(
+print $table_3_col(
     'strings added to Gaia 1.2',
     ['Key', 'en-US', $locale],
     $strings,

--- a/web/views/results.php
+++ b/web/views/results.php
@@ -13,13 +13,14 @@ if (mb_strlen(trim($my_search)) < 2) {
 // The search results are displayed into a table
 // (initial_search is the original sanitized searched string before any modification)
 
-$results = new ShowResults();
-$search_results = $results->getTMXResults(array_keys($locale1_strings), $tmx_source, $tmx_target);
+$searches = [
+	$source_locale => $locale1_strings,
+	$locale        => $locale2_strings
+];
 
-echo '<h2><span class="searchedTerm">' . $initial_search . '</span> in ' . $sourceLocale . ':</h2>';
-echo ShowResults::resultsTable($search_results, $initial_search, $sourceLocale, $locale, $check);
+foreach($searches as $key => $value) {
+	$search_results = ShowResults::getTMXResults(array_keys($value), [$tmx_source, $tmx_target]);
 
-$search_results = Utils::results(array_keys($locale2_strings), $tmx_source, $tmx_target);
-
-echo '<h2><span class="searchedTerm">' . $initial_search . '</span> in ' . $locale . ':</h2>';
-echo ShowResults::resultsTable($search_results, $initial_search, $sourceLocale, $locale, $check);
+    print '<h2><span class="searchedTerm">' . $initial_search . '</span> in ' . $key . ':</h2>';
+	print ShowResults::resultsTable($search_results, $initial_search, $source_locale, $locale, $check);
+}

--- a/web/views/results_ent.php
+++ b/web/views/results_ent.php
@@ -3,60 +3,60 @@ namespace Transvision;
 
 // rtl support
 $rtl = array('ar', 'fa', 'he');
-$direction1 = (in_array($sourceLocale, $rtl)) ? 'rtl' : 'ltr';
+$direction1 = (in_array($source_locale, $rtl)) ? 'rtl' : 'ltr';
 $direction2 = (in_array($locale, $rtl)) ? 'rtl' : 'ltr';
 
 // Get cached bugzilla components (languages list) or connect to Bugzilla API to retrieve them
-$bugzillaComponent = rawurlencode(
+$bugzilla_component = rawurlencode(
     Bugzilla::collectLanguageComponent(
         $locale,
         Bugzilla::getBugzillaComponents()
     )
 );
 
-$bugzillaLink = 'https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&component='
-               . $bugzillaComponent
+$bugzilla_link = 'https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&component='
+               . $bugzilla_component
                . '&product=Mozilla%20Localizations&status_whiteboard=%5Btransvision-feedback%5D';
 
 $table = "<table>
             <tr>
                 <th>Entity</th>\n
-                <th>" . $sourceLocale . "</th>
+                <th>" . $source_locale . "</th>
                 <th>" . $locale . "</th>
             </tr>";
 
 foreach ($entities as $val) {
 
-    $path_locale1 = VersionControl::filePath($sourceLocale, $check['repo'], $val);
+    $path_locale1 = VersionControl::filePath($source_locale, $check['repo'], $val);
     $path_locale2 = VersionControl::filePath($locale, $check['repo'], $val);
 
     if (isset($tmx_target[$val])) {
         // nbsp highlight
-        $targetString = str_replace(' ', '<span class="highlight-gray"> </span>', $tmx_target[$val]);
+        $target_string = str_replace(' ', '<span class="highlight-gray"> </span>', $tmx_target[$val]);
     } else {
-        $targetString = '';
+        $target_string = '';
     }
 
-    $sourceString = $tmx_source[$val];
+    $source_string = $tmx_source[$val];
 
     // Link to entity
-    $entityLink = "?sourcelocale={$sourceLocale}"
+    $entity_link = "?sourcelocale={$source_locale}"
                  . "&locale={$locale}"
                  . "&repo={$check['repo']}"
                  . "&search_type=entities&recherche={$val}";
 
-    $bugSummary = rawurlencode("Translation update proposed for {$val}");
-    $bugMessage = rawurlencode(
+    $bug_summary = rawurlencode("Translation update proposed for {$val}");
+    $bug_message = rawurlencode(
         html_entity_decode(
-            "The string:\n{$sourceString}\n\n"
-            . "Is translated as:\n{$targetString}\n\n"
+            "The string:\n{$source_string}\n\n"
+            . "Is translated as:\n{$target_string}\n\n"
             . "And should be:\n\n\n\n"
             . "Feedback via Transvision:\n"
-            . "http://transvision.mozfr.org/{$entityLink}"
+            . "http://transvision.mozfr.org/{$entity_link}"
         )
     );
 
-    $complete_link = $bugzillaLink . '&short_desc=' . $bugSummary . '&comment=' . $bugMessage;
+    $complete_link = $bugzilla_link . '&short_desc=' . $bug_summary . '&comment=' . $bug_message;
 
     $table .= "<tr>
                     <td>" . ShowResults::formatEntity($val, $my_search) . "</a></td>
@@ -67,7 +67,7 @@ foreach ($entities as $val) {
                        </div>
                     </td>
                      <td dir='{$direction2}'>
-                       <div class='string'>{$targetString}</div>
+                       <div class='string'>{$target_string}</div>
                        <div class='infos'>
                         <a class='source_link' href='{$path_locale2}'><em>&lt;source&gt;</em></a>
                         <a class='bug_link' target='_blank' href='{$complete_link}'>

--- a/web/views/search_form.php
+++ b/web/views/search_form.php
@@ -15,7 +15,7 @@ foreach ($repositories as $repository) {
     // build the target locale switcher
     $target_locales_list[$repository] = Utils::getHtmlSelectOptions($loc_list[$repository], $locale);
     // build the source locale switcher
-    $source_locales_list[$repository] = Utils::getHtmlSelectOptions($loc_list[$repository], $sourceLocale);
+    $source_locales_list[$repository] = Utils::getHtmlSelectOptions($loc_list[$repository], $source_locale);
 }
 
 // Build the search type switcher
@@ -27,17 +27,19 @@ $search_type_list = Utils::getHtmlSelectOptions(
 );
 
 // Get COOKIES
-$cookieTargetLocale = '';
+$cookie_target_locale = '';
 if (isset($_COOKIE['default_target_locale'])) {
-    $cookieTargetLocale = $_COOKIE['default_target_locale'];
+    $cookie_target_locale = $_COOKIE['default_target_locale'];
 }
-$cookieSourceLocale = '';
+
+$cookie_source_locale = '';
 if (isset($_COOKIE['default_source_locale'])) {
-    $cookieSourceLocale = $_COOKIE['default_source_locale'];
+    $cookie_source_locale = $_COOKIE['default_source_locale'];
 }
-$cookieRepository   = '';
+
+$cookie_repository   = '';
 if (isset($_COOKIE['default_repository'])) {
-    $cookieRepository   = $_COOKIE['default_repository'];
+    $cookie_repository   = $_COOKIE['default_repository'];
 }
 
 ?>
@@ -55,9 +57,9 @@ if (isset($_COOKIE['default_repository'])) {
                     <input type="checkbox"
                            id="default_repository"
                            value="<?=$check['repo']?>"
-                           data-cookie="<?=$cookieRepository?>"
+                           data-cookie="<?=$cookie_repository?>"
                            onclick="setCookie('default_repository',this.value,3650);"
-                           <?=Utils::checkboxDefaultOption($check['repo'], $cookieRepository)?>
+                           <?=Utils::checkboxDefaultOption($check['repo'], $cookie_repository)?>
                      /> <span>Default</span>
                  </label>
             </fieldset>
@@ -69,12 +71,12 @@ if (isset($_COOKIE['default_repository'])) {
                 <label class="default_option">
                     <input type="checkbox"
                            id="default_source_locale"
-                           value="<?=$sourceLocale?>"
-                           data-cookie="<?=$cookieSourceLocale?>"
+                           value="<?=$source_locale?>"
+                           data-cookie="<?=$cookie_source_locale?>"
                            onclick="setCookie('default_source_locale',this.value,3650);"
-<?php // Mark as default only if the cookieSourceLocale exist in repository array
-if (in_array($cookieSourceLocale, $loc_list[$check['repo']])) {
-    echo Utils::checkboxDefaultOption($sourceLocale, $cookieSourceLocale);
+<?php // Mark as default only if the cookie_source_locale exist in repository array
+if (in_array($cookie_source_locale, $loc_list[$check['repo']])) {
+    echo Utils::checkboxDefaultOption($source_locale, $cookie_source_locale);
 }
 ?>
                      /> <span>Default</span>
@@ -89,11 +91,11 @@ if (in_array($cookieSourceLocale, $loc_list[$check['repo']])) {
                     <input type="checkbox"
                            id="default_target_locale"
                            value="<?=$locale?>"
-                           data-cookie="<?=$cookieTargetLocale?>"
+                           data-cookie="<?=$cookie_target_locale?>"
                            onclick="setCookie('default_target_locale',this.value,3650);"
-<?php // Mark as default only if the cookieTargetLocale exist in repository array
-if (in_array($cookieTargetLocale, $loc_list[$check['repo']])) {
-    echo Utils::checkboxDefaultOption($locale, $cookieTargetLocale);
+<?php // Mark as default only if the cookie_target_locale exist in repository array
+if (in_array($cookie_target_locale, $loc_list[$check['repo']])) {
+    echo Utils::checkboxDefaultOption($locale, $cookie_target_locale);
 }
 ?>
                      /> <span>Default</span>

--- a/web/views/showrepos.php
+++ b/web/views/showrepos.php
@@ -16,21 +16,21 @@ foreach ($repos as $val) {
 
 // Using a callback with strlen() avoids filtering out numeric strings with a value of 0
 $strings['en-US'][$repo] = array_filter(Utils::getRepoStrings('en-US', $repo), 'strlen');
-$gaiaLocales = Utils::getFilenamesInFolder(TMX . $repo . '/');
+$gaia_locales = Utils::getFilenamesInFolder(TMX . $repo . '/');
 
 // We don't want en-US in the repos
-if ($key = array_search('en-US', $gaiaLocales)) {
-    unset($gaiaLocales[$key]);
+if ($key = array_search('en-US', $gaia_locales)) {
+    unset($gaia_locales[$key]);
 }
 
-$stringCount = array();
+$string_count = array();
 
-// Reference locale count
-$countReference = count($strings['en-US'][$repo]);
+// Referen_ce locale count
+$count_reference = count($strings['en-US'][$repo]);
 
-foreach ($gaiaLocales as $val) {
+foreach ($gaia_locales as $val) {
     $strings[$val][$repo] = array_filter(Utils::getRepoStrings($val, $repo), 'strlen');
-    $stringCount[$val] = array(
+    $string_count[$val] = array(
         'total'     => count($strings[$val][$repo]),
         'missing'   => count(array_diff_key($strings['en-US'][$repo], $strings[$val][$repo])),
         'identical' => count(array_intersect_assoc($strings['en-US'][$repo], $strings[$val][$repo])),
@@ -52,10 +52,10 @@ $table = '
     <th>Status estimate</th>
 </tr>';
 
-foreach ($stringCount as $locale => $numbers) {
+foreach ($string_count as $locale => $numbers) {
 
-    $completion = $countReference - $numbers['identical'] - $numbers['missing'];
-    $completion = number_format($completion/$countReference*100);
+    $completion = $count_reference - $numbers['identical'] - $numbers['missing'];
+    $completion = number_format($completion/$count_reference*100);
 
     if ($completion >= 99) {
         $confidence = 'Highest';

--- a/web/views/t2t.php
+++ b/web/views/t2t.php
@@ -62,7 +62,7 @@ foreach ($search as $word) {
 // remove duplicates
 $imperfect = array_unique($imperfect);
 
-$getResults = function($arr) use ($tmx_target) {
+$get_results = function($arr) use ($tmx_target) {
     $results = array();
     foreach ($arr as $val) {
         if ($tmx_target[$val] != '') {
@@ -75,12 +75,12 @@ $getResults = function($arr) use ($tmx_target) {
     return $results;
 };
 
-$perfect_results = $getResults($perfect);
-$imperfect_results = $getResults($imperfect);
+$perfect_results   = $get_results($perfect);
+$imperfect_results = $get_results($imperfect);
 
 if (count($perfect_results) > 0) {
     echo '<b>Perfect matches</b>';
-    echo "<ol dir='$localeDir'>";
+    echo "<ol dir='$locale_dir'>";
     foreach ($perfect_results as $val) {
         echo '<li>' . strip_tags(htmlspecialchars_decode($val)) . '</li>';
     }
@@ -93,8 +93,8 @@ echo '<b>Used in</b>';
 echo "<table>";
 foreach ($imperfect_results as $key => $val) {
     echo '<tr>';
-    echo "<td dir='$localeDir'>" . strip_tags(htmlspecialchars_decode($val)) . '</td>';
-    echo "<td dir='$sourceLocaleDir'>" . strip_tags(htmlspecialchars_decode($tmx_source[$key])) . '</td>';
+    echo "<td dir='$locale_dir'>" . strip_tags(htmlspecialchars_decode($val)) . '</td>';
+    echo "<td dir='$source_locale_dir'>" . strip_tags(htmlspecialchars_decode($tmx_source[$key])) . '</td>';
     echo '</tr>';
 }
 echo "</table>";

--- a/web/views/template.php
+++ b/web/views/template.php
@@ -1,6 +1,6 @@
 <?php
 $check['repo'] = isset($check['repo']) ? $check['repo'] : 'central';
-$sourceLocale = isset($sourceLocale) ? $sourceLocale : 'en-US';
+$source_locale = isset($source_locale) ? $source_locale : 'en-US';
 $locale = isset($locale) ? $locale : 'fr';
 $initial_search = isset($initial_search) ? $initial_search : 'Bookmarks';
 $initial_search = isset($initial_search) ? $initial_search : 'Bookmarks';
@@ -8,7 +8,7 @@ $initial_search = isset($initial_search) ? $initial_search : 'Bookmarks';
 $links = '
 <ul>
     <li><a href="/" title="Main search">Home</a></li>
-    <li><a ' . (isset($_GET['t2t']) ? 'class="select" ' : '') . 'href="/?sourcelocale=' . $sourceLocale . '&locale=' . $locale . '&repo=' . $check['repo'] . '&t2t=t2t&recherche=' . $initial_search . '" title="Search in the Glossary">Glossary</a></li>
+    <li><a ' . (isset($_GET['t2t']) ? 'class="select" ' : '') . 'href="/?sourcelocale=' . $source_locale . '&locale=' . $locale . '&repo=' . $check['repo'] . '&t2t=t2t&recherche=' . $initial_search . '" title="Search in the Glossary">Glossary</a></li>
     <li><a ' . ($url['path'] == 'accesskeys' ? 'class="select" ' : '') . 'href="/accesskeys/" title="Check your access keys">Access Keys</a></li>
     <li><a ' . ($url['path'] == 'channelcomparison' ? 'class="select" ' : '') . 'href="/channelcomparison/" title="Compare strings from channel to channel">Channel Comparison</a></li>
     <li><a ' . ($url['path'] == 'gaia' ? 'class="select" ' : '') . 'href="/gaia/" title="Compare strings across Gaia channels">Gaia Comparison</a></li>


### PR DESCRIPTION
- Create ShowResults::getStringFromEntity($entity, $strings) + unit tests
- Make ShowResults::getStringFromEntity() accept an array of localized strings, not just 2 arrays, so as to be able to return results for more than 2 locales
- update views/results.php to use the changes aboveand use a loop to avoid code repetition
- general cleanup of variables to fix typos and consistently use underscore for naming
