### PR TITLE
Make search possible for special characters (", <, >, etc.)

### DIFF
--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -21,10 +21,10 @@ class Utils
         $sanitize = function($v) {
             // CRLF XSS
             $v = str_replace(['%0D', '%0A'], '', $v);
-            // Remove html tags and ASCII characters below 32
+            // Escape HTML tags and remove ASCII characters below 32
             $v = filter_var(
                 $v,
-                FILTER_SANITIZE_STRING,
+                FILTER_SANITIZE_SPECIAL_CHARS,
                 FILTER_FLAG_STRIP_LOW
             );
             return $v;

--- a/app/inc/mozorg.php
+++ b/app/inc/mozorg.php
@@ -34,7 +34,7 @@ foreach (Files::getFilenamesInFolder( SVN . 'mozilla_org/') as $locale) {
                     "'"
                    . Dotlang::generateStringID('mozilla_org/' . $file, $str1)
                    . "' => '"
-                   . htmlspecialchars($str2, ENT_QUOTES)
+                   . Utils::secureText($str2)
                    . "',"
                    . "\n";
 

--- a/app/inc/recherche.php
+++ b/app/inc/recherche.php
@@ -9,8 +9,8 @@ $tmx_target = Utils::getRepoStrings($locale, $check['repo']);
 $whole_word     = $check['whole_word']     ? '\b' : '';
 $case_sensitive = $check['case_sensitive'] ? '' : 'i';
 
-$regex = '/' . $whole_word . $my_search . $whole_word . '/' . $case_sensitive;
-
+$delimiter = '~';
+$regex = $delimiter . $whole_word . $my_search . $whole_word . $delimiter . $case_sensitive;
 $entities = preg_grep($regex, array_keys($tmx_source));
 
 if ($check['perfect_match']) {
@@ -21,7 +21,7 @@ if ($check['perfect_match']) {
     $locale1_strings = $tmx_source;
     $locale2_strings = $tmx_target;
     foreach ($search as $word) {
-        $regex = '/' . $whole_word . preg_quote($word, '/') . $whole_word . '/' . $case_sensitive;
+        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) . $whole_word . $delimiter . $case_sensitive;
         $locale1_strings = preg_grep($regex, $locale1_strings);
         $locale2_strings = preg_grep($regex, $locale2_strings);
     }
@@ -46,7 +46,7 @@ if ($url['path'] == '3locales') {
     } else {
         $locale3_strings = $tmx_target2;
         foreach ($search as $word) {
-            $regex = '/' . $whole_word . preg_quote($word, '/') . $whole_word . '/' . $case_sensitive;
+            $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) . $whole_word . $delimiter . $case_sensitive;
             $locale3_strings = preg_grep($regex, $locale3_strings);
         }
     }

--- a/tmxmaker.py
+++ b/tmxmaker.py
@@ -28,12 +28,12 @@ def escape(t):
         .replace("&quot;", '@quot;')
         .replace("&amp;", "@amp;").replace("&lt;", "@lt;").replace("&gt;", "@gt;")
 
-        .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        .replace("'", "&#39;").replace('"', "&quot;")
+        .replace("&", "&amp;").replace("<", "&#60;").replace(">", "&#62;")
+        .replace("'", "&#39;").replace('"', "&#34;")
         .replace("\\", "&#92;")
 
-        .replace("@quot;", '&quot;')
-        .replace("@amp;", "&amp;").replace("@lt;", "&lt;").replace("@gt;", "&gt;")
+        .replace("@quot;", '&#34;')
+        .replace("@amp;", "&amp;").replace("@lt;", "&#60;").replace("@gt;", "&#62;")
 
         )
 


### PR DESCRIPTION
- Change storage of keys in tmxmaker (utf-8 characters instead of HTML entities)
- Change filtering of search strings
- Use Utils:secureText instead of htmlspecialchars for mozorg
