### PR TITLE
Project class: add method to manage locale exception, update Gaia locales

### DIFF
--- a/app/classes/Transvision/Bugzilla.php
+++ b/app/classes/Transvision/Bugzilla.php
@@ -39,9 +39,7 @@ class Bugzilla
      */
     public static function collectLanguageComponent($actual_lang, $components_array)
     {
-        $actual_lang = ($actual_lang == 'es') ? 'es-ES' : $actual_lang;
-        $actual_lang = ($actual_lang == 'pa') ? 'pa-IN' : $actual_lang;
-        $actual_lang = Bugzilla::bugzillaLocaleCode($actual_lang);
+        $actual_lang = Project::getLocaleInContext($actual_lang, 'bugzilla');
 
         $component_string = 'Other';
         $actual_lang = $actual_lang . ' /';
@@ -54,22 +52,6 @@ class Bugzilla
         }
 
         return $component_string;
-    }
-
-    /*
-     * Get the locale code we use on Bugzilla for components
-     * It can differ from what we have in the products for historical reasons
-     *
-     * @param $locale string
-     * @return $locale string
-     */
-    public static function bugzillaLocaleCode($locale)
-    {
-        $locale = ($locale == 'es') ? 'es-ES' : $locale;
-        $locale = ($locale == 'pa') ? 'pa-IN' : $locale;
-        $locale = ($locale == 'sr-Cyrl' || $locale == 'sr-Latn') ? 'sr' : $locale;
-
-        return $locale;
     }
 
     /**

--- a/app/classes/Transvision/Project.php
+++ b/app/classes/Transvision/Project.php
@@ -119,4 +119,57 @@ class Project
     {
         return in_array($repository, self::getRepositories());
     }
+
+    /**
+     * Return the correct locale code based on context
+     * For example: given "es", returns "es-ES" for Bugzilla,
+     * "es" for Gaia, "es-ES" for other repos.
+     *
+     * @param  string $locale Name of the current locale
+     * @param  string $context The context we need to use this locale in
+     * @return string Locale code to use in the requested context
+     */
+    public static function getLocaleInContext($locale, $context)
+    {
+        $locale_mappings = [];
+
+        // Bugzilla locales
+        $locale_mappings['bugzilla'] = [
+            'es'      => 'es-ES',
+            'gu'      => 'gu-IN',
+            'pa'      => 'pa-IN',
+            'sr-Cyrl' => 'sr',
+            'sr-Latn' => 'sr',
+        ];
+
+        // Gaia locales
+        $locale_mappings['gaia'] = [
+            'es-AR' => 'es',
+            'es-CL' => 'es',
+            'es-ES' => 'es',
+            'es-MX' => 'es',
+            'gu-in' => 'gu',
+            'pa-in' => 'pa',
+            'sr'    => 'sr-Cyrl',
+        ];
+
+        // Other contexts. At the moment, identical to Bugzilla list
+        $locale_mappings['other'] = $locale_mappings['bugzilla'];
+
+        // Use Gaia mapping for all Gaia repositories
+        if (Strings::startsWith($context, 'gaia')) {
+            $context = 'gaia';
+        }
+
+        // Fallback to 'other' if context doesn't exist in $locale_mappings
+        $context = array_key_exists($context, $locale_mappings)
+                   ? $context
+                   : 'other';
+
+        $locale = array_key_exists($locale, $locale_mappings[$context])
+                  ? $locale_mappings[$context][$locale]
+                  : $locale;
+
+        return $locale;
+    }
 }

--- a/app/config/gaia.txt
+++ b/app/config/gaia.txt
@@ -12,11 +12,13 @@ cy
 da
 de
 el
+en-GB
 en-US
 eo
 es
 et
 eu
+fa
 ff
 fr
 fy-NL
@@ -38,9 +40,11 @@ ko
 lij
 lt
 mai
-ml
 mk
+ml
+mr
 ms
+nb-NO
 ne-NP
 nl
 or
@@ -57,6 +61,7 @@ sq
 sr-Cyrl
 sr-Latn
 sv-SE
+sw
 ta
 te
 th

--- a/app/config/gaia_1_4.txt
+++ b/app/config/gaia_1_4.txt
@@ -12,11 +12,13 @@ cy
 da
 de
 el
+en-GB
 en-US
 eo
 es
 et
 eu
+fa
 ff
 fr
 fy-NL
@@ -37,9 +39,11 @@ kn
 ko
 lij
 lt
-ml
 mk
+ml
+mr
 ms
+nb-NO
 ne-NP
 nl
 or

--- a/app/inc/l10n-init.php
+++ b/app/inc/l10n-init.php
@@ -9,7 +9,9 @@ if (isset($_GET['repo'])) {
             ? $_GET['repo']
             : 'central';
 } else {
-    $repo = 'central';
+    if (! isset($repo)) {
+        $repo = 'central';
+    }
 }
 
 $all_locales = Project::getRepositoryLocales($repo);

--- a/app/views/accesskeys.php
+++ b/app/views/accesskeys.php
@@ -28,13 +28,7 @@ $channel_selector = Utils::getHtmlSelectOptions(
     true);
 
 // Get the locale list
-$loc_list = Files::getFilenamesInFolder(TMX . $repo . '/');
-
-// Gaia hack
-$spanish  = array_search('es', $loc_list);
-if ($spanish) {
-    $loc_list[$spanish] = 'es-ES';
-}
+$loc_list = Project::getRepositoryLocales($repo);
 
 // build the target locale switcher
 $target_locales_list = Utils::getHtmlSelectOptions($loc_list, $locale);

--- a/app/views/changelog.php
+++ b/app/views/changelog.php
@@ -1,6 +1,7 @@
 <h2 class="relnumber" id="v3.3"><a href="#v3.3">Version 3.3 <span class="reldate">2014-05-20</span></a></h2>
 
 <h3>End user visible changes</h3>
+<ul>
     <li><span class="newfeature">new</span><strong>Search hints:</strong> If your search for a word or entity yields no result, Transvision <a href="/?recherche=lookmark&repo=central&sourcelocale=en-US&locale=fr&search_type=strings">proposes similar searches that do yield results</a> (pascal).</li>
     <li><span class="newfeature">new</span><strong>Dynamic Gaia comparison view:</strong> allows <a href="/gaia/?locale=fr&amp;repo1=gaia_1_3&amp;repo2=gaia_1_4">comparison of combinations of repositories/locales</a> (tchevalier)</li>
     <li>Gaia 1.4 support (tchevalier)</li>
@@ -9,7 +10,6 @@
     <li>Tamil added for Gaia (flod)</li>
     <li>Fixed error 500 error when downloading TMX files (flod)</li>
     <li>Improved accessibility of our views, suggestions by experts from <a href="http://acs-horizons.fr/">ACS Horizons</a> and <a href="http://temesis.com/">Temesis</a> (pascal)</li>
-<ul>
 </ul>
 
 <h3>Developer visible changes</h3>

--- a/app/views/checkvariables.php
+++ b/app/views/checkvariables.php
@@ -8,16 +8,9 @@ $direction1 = RTLSupport::getDirection($source_locale);
 $direction2 = RTLSupport::getDirection($locale);
 
 if (isset($_GET['locale'])) {
-    if (Strings::startsWith($repo, 'gaia')) {
-        if (Strings::startsWith($_GET['locale'], 'es-')) {
-            $locale = 'es';
-        }
-
-        if ($_GET['locale'] == 'sr') {
-            $locale = 'sr-Cyrl';
-        }
-    } elseif (in_array($_GET['locale'], $all_locales)) {
-        $locale = $_GET['locale'];
+    $requested_locale = Project::getLocaleInContext($_GET['locale'], $repo);
+    if (in_array($requested_locale, $all_locales)) {
+        $locale = $requested_locale;
     }
 }
 

--- a/app/views/gaia.php
+++ b/app/views/gaia.php
@@ -1,11 +1,9 @@
 <?php
 namespace Transvision;
 
+// Set $repo to get the correct list of locales for Gaia from l10n-init.php
+$repo = 'gaia';
 require_once INC . 'l10n-init.php';
-
-// Serbian hack
-$all_locales[] = 'sr-Cyrl';
-$all_locales[] = 'sr-Latn';
 
 // Functions
 $get_or_set = function($arr, $value, $fallback) {

--- a/app/views/productization.php
+++ b/app/views/productization.php
@@ -50,7 +50,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
     echo "\n\n   <div class='product'>\n" .
          "    <h3>{$productnames[$i]}<br/>Searchplugins</h3>\n";
     if (array_key_exists($product, $jsonarray[$locale])) {
-        # This product exists for locale
+        // This product exists for locale
         foreach ($channels as $channel) {
             echo "    <div class='channel'>\n" .
                  "      <h4>$channel</h4>\n";
@@ -86,7 +86,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
                         echo "        </div>\n";                        }
                 }
             } else {
-                # Product exists, but not on this channel
+                // Product exists, but not on this channel
                 echo "      <div class='searchplugin'>\n";
                 echo "        <p class='emptysp'>Searchplugins not available for this update channel.</p>\n";
                 echo "      </div>\n";
@@ -96,7 +96,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
 
         echo "\n    <h3>Search order</h3>\n";
         if (array_key_exists($product, $jsonarray[$locale])) {
-            # This product exists for locale
+            // This product exists for locale
             foreach ($channels as $channel) {
                 echo "    <div class='channel'>\n" .
                      "      <h4>$channel</h4>\n";
@@ -119,7 +119,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
                         echo "        </div>\n";
                     }
                 } else {
-                    # Product exists, but not on this channel
+                    // Product exists, but not on this channel
                     echo "        <div class='searchorder'>\n";
                     echo "          <p class='emptysp'>This product is not available for this update channel.</p>\n";
                     echo "        </div>\n";
@@ -130,7 +130,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
 
         echo "\n    <h3>Protocol handlers</h3>\n";
         if (array_key_exists($product, $jsonarray[$locale])) {
-            # This product exists for locale
+            // This product exists for locale
             foreach ($channels as $channel) {
                 echo "    <div class='channel'>\n" .
                      "      <h4>$channel</h4>\n";
@@ -164,7 +164,7 @@ if (!file_exists(WEB_ROOT . 'p12n/searchplugins.json')) {
                         echo "        </div>\n";
                     }
                 } else {
-                    # Product exists, but not on this channel
+                    // Product exists, but not on this channel
                     echo "        <div class='searchorder'>\n";
                     echo "          <p class='emptysp'>This product is not available for this update channel.</p>\n";
                     echo "        </div>\n";

--- a/tests/units/Transvision/Bugzilla.php
+++ b/tests/units/Transvision/Bugzilla.php
@@ -57,30 +57,6 @@ class Bugzilla extends atoum\test
         ;
     }
 
-    public function bugzillaLocaleCodeDP()
-    {
-        return array(
-            array( 'fr', 'fr'),
-            array( 'es', 'es-ES'),
-            array( 'pa', 'pa-IN'),
-            array( 'sr', 'sr'),
-            array( 'sr-Cyrl', 'sr'),
-            array( 'sr-Latn', 'sr'),
-        );
-    }
-
-    /**
-     * @dataProvider bugzillaLocaleCodeDP
-     */
-    public function testBugzillaLocaleCode($a, $b)
-    {
-        $obj = new \Transvision\Bugzilla();
-        $this
-            ->string($obj->bugzillaLocaleCode($a))
-                ->isEqualTo($b)
-        ;
-    }
-
     public function reportErrorLinkDP()
     {
         return array(

--- a/tests/units/Transvision/Project.php
+++ b/tests/units/Transvision/Project.php
@@ -83,4 +83,39 @@ class Project extends atoum\test
             ->boolean($obj->isValidRepository('foo'))
                 ->isEqualTo(false);
     }
+
+    public function testGetLocaleInContextDP()
+    {
+        return [
+                ['fr', 'bugzilla', 'fr'],
+                ['es', 'bugzilla', 'es-ES'],
+                ['pa', 'bugzilla', 'pa-IN'],
+                ['gu', 'bugzilla', 'gu-IN'],
+                ['sr', 'bugzilla', 'sr'],
+                ['sr-Cyrl', 'bugzilla', 'sr'],
+                ['sr-Latn', 'bugzilla', 'sr'],
+                ['sr-Latn', 'gaia', 'sr-Latn'],
+                ['sr', 'gaia', 'sr-Cyrl'],
+                ['es', 'gaia', 'es'],
+                ['es-CL', 'gaia', 'es'],
+                ['es-ES', 'gaia_1_4', 'es'],
+                ['es', 'mozilla_org', 'es-ES'],
+                ['es-AR', 'mozilla_org', 'es-AR'],
+                ['sr-Cyrl', 'mozilla_org', 'sr'],
+                ['es-ES', 'foobar', 'es-ES'],
+                ['fr', 'foobar', 'fr'],
+               ];
+    }
+
+    /**
+     * @dataProvider testGetLocaleInContextDP
+     */
+    public function testGetLocaleInContext($a, $b, $c)
+    {
+        $obj = new \Transvision\Project();
+        $this
+            ->string($obj->getLocaleInContext($a, $b))
+                ->isEqualTo($c)
+        ;
+    }
 }


### PR DESCRIPTION
- Move code from Bugzilla to manage exceptions in a single place in the code
- Clean up some views:
  - accesskey: use `getRepositoryLocales`, no need for Gaia hack (no accesskeys in Gaia).
  - changelog: fix markup error.
  - checkvariables: use `getLocaleInContext`.
  - gaia: remove Serbian hack, tweak `l10n-init.php` to return the list of locales for Gaia in $all_locales.
  - productization: fix comment style.
- Update Gaia locales (master, 1.4): en-GB, fa, mr, nb-NO, sw.
