### PR TITLE
Refactor new tmx downloads view:

### DIFF
--- a/app/classes/Transvision/TMX.php
+++ b/app/classes/Transvision/TMX.php
@@ -33,12 +33,12 @@ class TMX
                 $string_source = htmlentities($string_source, ENT_XML1);
                 $string_target = htmlentities($string_target, ENT_XML1);
 
-                $content .= '    <tu tuid="' . $entity . '" srclang="' . $source_lang . '">' . "\n"
-                            .'        <tuv xml:lang="' . $source_lang . '"><seg>' . $string_source . '</seg></tuv>' . "\n"
-                            .'        <tuv xml:lang="' . $target_lang . '"><seg>' . $string_target . '</seg></tuv>' . "\n"
-                            .'    </tu>' . "\n";
+                $content .= "\t".'<tu tuid="' . $entity . '" srclang="' . $source_lang . '">' . "\n"
+                            . "\t\t" . '<tuv xml:lang="' . $source_lang . '"><seg>' . $string_source . '</seg></tuv>' . "\n"
+                            . "\t\t" . '<tuv xml:lang="' . $target_lang . '"><seg>' . $string_target . '</seg></tuv>' . "\n"
+                            . "\t" . '</tu>' . "\n";
             }
-            $content .= "</body>\n</tmx>";
+            $content .= "</body>\n</tmx>\n";
 
             return $content;
         }

--- a/app/models/tmx_downloading.php
+++ b/app/models/tmx_downloading.php
@@ -1,34 +1,51 @@
 <?php
 namespace Transvision;
 
-// Get strings for selected repos
-$strings = ['en-US' => [], $locale => []];
 $missing_repos = $available_repos = $results = '';
 $missing_repos_count = $repos_count = 0;
+$strings = ['en-US' => [], $locale => []];
 
 foreach ($repos as $repo) {
     if (isset($_GET[$repo])) {
-        $cache_file_en = Utils::getRepoStrings(Project::getReferenceLocale($repo), $repo);
-        $cache_file_locale = Utils::getRepoStrings($locale, $repo);
-        if ($cache_file_en) {
+
+        $cache_file_english = Utils::getRepoStrings(Project::getReferenceLocale($repo), $repo);
+
+        if ($cache_file_english) {
+
+            $cache_file_locale = Utils::getRepoStrings($locale, $repo);
+
+            if ($repo == 'mozilla_org') {
+                $cache_file_locale = array_map(
+                    function($e) {
+                        return trim(rtrim($e, '{ok}'));
+                    },
+                    $cache_file_locale
+                );
+            }
+
+            // If a repo is missing, we don't have additional keys
             if ($cache_file_locale) {
-                // If mozilla_org, remove {ok} tags
-                if ($repo == 'mozilla_org') {
-                    foreach ($cache_file_locale as $key => $value) {
-                        $cache_file_locale[$key] = trim(rtrim($cache_file_locale[$key], '{ok}'));
-                    }
-                }
-                $strings['en-US'] = array_merge($cache_file_en, $strings['en-US']);
-                $strings[$locale] = array_merge($cache_file_locale, $strings[$locale]);
+                $strings['en-US'] = array_merge($strings['en-US'], $cache_file_english);
+                $strings[$locale] = array_merge($strings[$locale], $cache_file_locale);
                 $repos_count++;
                 $available_repos .= '<br>' . $repos_nice_names[$repo] . ' (' . $locale . ')';
+                unset($cache_file_locale);
             } else {
-                $missing_repos .= '<br>' . $repos_nice_names[$repo] . ' (' . $locale . ')';
                 $missing_repos_count++;
+                $missing_repos .= '<br>' . $repos_nice_names[$repo] . ' (' . $locale . ')';
             }
+
+            unset($cache_file_english);
         }
     }
 }
+
+// We filter empty values but we keep 0 values with strlen
+$strings = [
+    'en-US' => array_filter($strings['en-US'], 'strlen'),
+    $locale => array_filter($strings[$locale], 'strlen'),
+];
+
 $empty_TMX = $repos_count == 0;
 
 // Generate the TMX file
@@ -37,12 +54,14 @@ $target_file_path = WEB_ROOT . 'download/' . $target_file;
 
 $content = TMX::create($strings, $locale, 'en-US');
 unset($strings);
+
 $empty_TMX = $created_TMX = false;
 
 if ($content) {
     if (! file_put_contents($target_file_path, $content)) {
-        $logger->error('Can\'t write into web/download folder');
+        $logger->error("Can't write into web/download folder");
     }
 } else {
     $empty_TMX = true;
 }
+

--- a/tests/units/Transvision/TMX.php
+++ b/tests/units/Transvision/TMX.php
@@ -25,17 +25,17 @@ class TMX extends atoum\test
 <tmx version="1.4">
 <header o-tmf="plain text" o-encoding="UTF8" adminlang="en" creationdate="'. date('c') . '" creationtoolversion="0.1" creationtool="Transvision" srclang="en-US" segtype="sentence" datatype="plaintext">
 </header>
-<body>
-    <tu tuid="shared/date/date.properties:month-7-genitive" srclang="en-US">
-        <tuv xml:lang="en-US"><seg>August</seg></tuv>
-        <tuv xml:lang="fr"><seg>août</seg></tuv>
-    </tu>
-    <tu tuid="shared/download/download.properties:unsupported_file_type_download_title" srclang="en-US">
-        <tuv xml:lang="en-US"><seg>Unable to open</seg></tuv>
-        <tuv xml:lang="fr"><seg>Ouverture impossible</seg></tuv>
-    </tu>
+<body>'
+. "\n\t" . '<tu tuid="shared/date/date.properties:month-7-genitive" srclang="en-US">'
+. "\n\t\t" . '<tuv xml:lang="en-US"><seg>August</seg></tuv>'
+. "\n\t\t" . '<tuv xml:lang="fr"><seg>août</seg></tuv>'
+. "\n\t" . '</tu>'
+. "\n\t" . '<tu tuid="shared/download/download.properties:unsupported_file_type_download_title" srclang="en-US">'
+. "\n\t\t" . '<tuv xml:lang="en-US"><seg>Unable to open</seg></tuv>'
+. "\n\t\t" . '<tuv xml:lang="fr"><seg>Ouverture impossible</seg></tuv>'
+. "\n\t" . '</tu>
 </body>
-</tmx>'
+</tmx>'. "\n"
             )
         );
     }


### PR DESCRIPTION
- consume a bit less memory in general (ex: 27MB instead of 29MB when selecting all repos for French, 14.5MB instead of 22MB when selecting only mozilla-central for Persian)
- don't put empty strings in tmx output
- use tabs instead of spaces in generated tmx (saves up to 2MB memory in file size and 0.5MB in memory consumption)
