### PR TITLE
Issue #307: fix API regresssions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Transvision team uses Git and GitHub for both development and issue tracking
 2. Clone your fork to your machine.
 3. Copy app/config/config.ini-dev to app/config/config.ini and adapt the variables to your system.
 4. Run "app/scripts/dev-setup.sh". This process may take some time as it downloads a snapshot of data from Transvision server (~400MB). It will also download Composer, the PHP dependency manager, and install the dependencies needed.
-5. You are set! You can run Transvision in your local machine with "php -S localhost:8080" inside the web/ folder and opening http://localhost:8080/ with your browser.
+5. You are set! You can run Transvision in your local machine with "php -S localhost:8082 -t web/ app/inc/router.php" in your install folder and opening http://localhost:8082/ with your browser.
 
 ## Update glossary
 

--- a/app/inc/router.php
+++ b/app/inc/router.php
@@ -9,13 +9,13 @@ if (file_exists($_SERVER['DOCUMENT_ROOT'] . $url['path'])
     return false;
 }
 
+// Define if an url is for the API or the site
+$api_url = (boolean) ! strncmp($url['path'], '/api/', strlen('/api/'));
+
 // Don't process non-PHP files, even if they don't exist on the server
-if ((isset($file['extension']) && $file['extension'] != 'php')) {
+if (isset($file['extension']) && $file['extension'] != 'php' && ! $api_url) {
     return false;
 }
-
-// Define if an url is for The API or the site
-$api_url = (boolean) !strncmp($url['path'], '/api/', strlen('/api/'));
 
 if ($url['path'] != '/') {
     // Normalize path before comparing the string to list of valid paths

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -10,7 +10,7 @@ $get_option = function($option) use ($request) {
 };
 
 // Get all strings
-$initial_search = Utils::cleanSearch($request->parameters[6]);
+$initial_search = urldecode(Utils::cleanSearch($request->parameters[6]));
 $source_strings = Utils::getRepoStrings($request->parameters[4], $request->parameters[3]);
 $target_strings = Utils::getRepoStrings($request->parameters[5], $request->parameters[3]);
 
@@ -24,6 +24,7 @@ if ($get_option('perfect_match')) {
         $entities = preg_grep($regex, array_keys($source_strings));
     } else {
         $source_strings = preg_grep($regex, $source_strings);
+        $entities = array_keys($source_strings);
     }
 } else {
     foreach (Utils::uniqueWords($initial_search) as $word) {

--- a/app/scripts/dev-setup.sh
+++ b/app/scripts/dev-setup.sh
@@ -40,6 +40,6 @@ php composer.phar install
 echogreen "Add stats.json file"
 touch web/stats.json
 
-echogreen "Launching PHP development server (php -S localhost:8080 in the web folder)"
-cd $root
-php -S localhost:8080
+echogreen "Launching PHP development server (php -S localhost:8082 -t web/ app/inc/router.php)"
+cd $install
+php -S localhost:8082 -t web/ app/inc/router.php


### PR DESCRIPTION
- allow strings with dots in router script for API calls
- escape slashes  when searching for an entity
- fix perfect_match search on string search returning no result
- adapt dev server script to run outside of the web folder (needed to allow dots in urls)
- change dev server port to 8082 (less likely to collide with another instance)
- redirects of API searches without a repo fallback to 'release' repository to not fail (no cookie to read with the api)
- updated README
