### PR TITLE
Improve variable detection in checkvariables.php

### DIFF
--- a/app/views/checkvariables.php
+++ b/app/views/checkvariables.php
@@ -43,8 +43,8 @@ if (Strings::startsWith($repo, 'gaia')) {
 } else {
     $regex_pattern = [
         'dtd'         => '/&([a-z0-9\.]+);/i', // &foobar;
-        'properties1' => '/%[0-9]*\$S/', // %1$S
-        'properties2' => '/\s\$[a-z0-9\.]+\s/i' // $BrandShortName
+        'properties1' => '/%([0-9]+\$){0,1}S/i', // %1$S or %S, case insensitive
+        'properties2' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i' // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
     ];
 }
 


### PR DESCRIPTION
```
/%([0-9]+\$){0,1}S/i
```

This also detects %s or %S.
pro: you can find more errors ([example for cs](http://transvision.mozfr.org/?recherche=browser%2Fchrome%2Fbrowser%2Fdevtools%2Fappcacheutils.properties%3AescapeSpaces&repo=central&sourcelocale=en-US&locale=cs&search_type=strings_entities)).
neg: more false positives. Code now reports a mismatch between %S and %s, and %S and %1$S, and both are correct. The alternative is to put more logic in the class

```
/(?<!%[0-9])\$[a-z0-9\.]+\b/i
```

This now matches only "brandshortname" in "test brandshortname.". Negative lookbehind is used to avoid some false positive, example `My%1$SFeeds-%2$S.opml`.
