### PR TITLE
Check variables: move regexp to class, improve checks

### DIFF
--- a/app/classes/Transvision/AnalyseStrings.php
+++ b/app/classes/Transvision/AnalyseStrings.php
@@ -32,34 +32,68 @@ class AnalyseStrings
 
     /**
      * Search for strings with variables differences
-     * @param array $tmx_source TMX file as reference
-     * @param array $tmx_target TMX file for the locale to compare
-     * @param array  $patterns  list of regex patterns for the search
-     *               Pattern examples:
-     *               '/&([a-z0-9\.]+);/i'      -> &brandShortName;
-     *               '/\{\{([a-z0-9]+)\}\}/i'  -> {{brandShortName}}
+     * @param array  $tmx_source TMX file as reference
+     * @param array  $tmx_target TMX file for the locale to compare
+     * @param string $repo Name of the repo to determine the right set of regexps
      * @return array List of entity names not matching source
      */
-    public static function differences($tmx_source, $tmx_target, $patterns)
+    public static function differences($tmx_source, $tmx_target, $repo)
     {
         $pattern_mismatch = [];
 
-        if (!is_array($patterns)) {
-            $patterns = (array) $patterns;
+        if (Strings::startsWith($repo, 'gaia')) {
+            $patterns = [
+                'l10njs'     => '/\{\{([\s]*[a-z0-9]+[\s]*)\}\}/i' // {{foobar2}}
+            ];
+        } else {
+            $patterns = [
+                'dtd'        => '/&([a-z0-9\.]+);/i',                // &foobar;
+                'printf'     => '/%([0-9]+\$){0,1}([0-9].){0,1}S/i', // %1$S or %S. %1$0.S and %0.S are valid too
+                'properties' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i'      // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
+            ];
         }
 
-        foreach ($patterns as $pattern) {
+        foreach ($patterns as $pattern_name => $pattern) {
             foreach ($tmx_source as $key => $value) {
-                preg_match_all($pattern, $value, $matches);
-                if (count($matches[0]) > 0) {
-                    foreach ($matches[0] as $val) {
-                        if (isset($tmx_target[$key])
-                            && $tmx_target[$key] != ''
-                            && strpos(str_replace(' ' , '', $tmx_target[$key]),
-                                      str_replace(' ' , '', $val)) === false )
-                        {
-                            $pattern_mismatch[] = $key;
+                if (isset($tmx_target[$key])
+                    && $tmx_target[$key] != '') {
+                    //Check variables only if the translation exist
+                    $translation = $tmx_target[$key];
+                    $wrong_variable = false;
+                    preg_match_all($pattern, $value, $matches_source);
+                    if (count($matches_source[0]) > 0) {
+                        foreach ($matches_source[0] as $val) {
+                            if ($pattern_name == 'printf') {
+                                // Variables are in format %S or %1$S, case is not relevant
+                                if (stripos($translation, $val) === false) {
+                                   $wrong_variable = true;
+                                }
+                            } else {
+                                if (strpos($translation, $val) === false) {
+                                   $wrong_variable = true;
+                                }
+                            }
                         }
+                    }
+
+                    if ($pattern_name == 'printf') {
+                        preg_match_all('/%([0-9]+\$){1}([0-9].){0,1}S/i', $translation, $matches_ordered);
+                        preg_match_all('/%(0.){0,1}S/i', $translation, $matches_unordered);
+
+                        if ((count($matches_ordered[0]) > 0) &&
+                            (count($matches_unordered[0]) > 0)) {
+                            // A string can't have both ordered and unordered variables
+                            $wrong_variable = true;
+                        } elseif (count($matches_ordered[0]) + count($matches_unordered[0]) == count($matches_source[0])) {
+                            /* I have the same number of variables in source and translation,
+                             * I consider the string valid.
+                             */
+                            $wrong_variable = false;
+                        }
+                    }
+
+                    if ($wrong_variable) {
+                        $pattern_mismatch[] = $key;
                     }
                 }
             }

--- a/app/views/checkvariables.php
+++ b/app/views/checkvariables.php
@@ -38,17 +38,7 @@ include __DIR__ . '/simplesearchform.php';
 $source = array_map(['Transvision\AnalyseStrings', 'cleanUpEntities'], $source);
 $target = array_map(['Transvision\AnalyseStrings', 'cleanUpEntities'], $target);
 
-if (Strings::startsWith($repo, 'gaia')) {
-    $regex_pattern = '/\{\{([\s]*[a-z0-9]+[\s]*)\}\}/i'; // {{foobar2}}
-} else {
-    $regex_pattern = [
-        'dtd'         => '/&([a-z0-9\.]+);/i', // &foobar;
-        'properties1' => '/%([0-9]+\$){0,1}S/i', // %1$S or %S, case insensitive
-        'properties2' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i' // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
-    ];
-}
-
-$mismatch = AnalyseStrings::differences($source, $target, $regex_pattern);
+$mismatch = AnalyseStrings::differences($source, $target, $repo);
 
 // Get cached bugzilla components (languages list) or connect to Bugzilla API to retrieve them
 $bugzilla_component = rawurlencode(

--- a/tests/units/Transvision/AnalyseStrings.php
+++ b/tests/units/Transvision/AnalyseStrings.php
@@ -33,26 +33,82 @@ class AnalyseStrings extends atoum\test
             [
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label' => '&brandShortName; will:'],
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label' => 'Règles de conservation :'],
-                '/&([a-z0-9\.]+);/i',
+                'central',
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label']
             ],
             [
                 ['apps/settings/settings.properties:bt-status-paired[one]' => '{{name}}, +{{n}} more'],
                 ['apps/settings/settings.properties:bt-status-paired[one]' => '{{name}} et un autre'],
-                '/\{\{([a-z0-9]+)\}\}/i',
+                'gaia',
                 ['apps/settings/settings.properties:bt-status-paired[one]']
             ],
             [
                 ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH' => '$BrandShortName is already running.\n\nPlease close $BrandShortName prior to launching the version you have just installed.'],
                 ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH' => 'El $BrandFullName ja s\'està executant.\n\nTanqueu el $BrandFullName abans d\'executar la versió que acabeu d\'instal·lar.'],
-                ['/\$[a-z0-9\.]+\s/i', '/&([a-z0-9\.]+);/i'],
-                ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH','browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH']
+                'aurora',
+                ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH']
+            ],
+            [
+                // Variable format %S
+                ['browser:foobar' => 'A username and password are being requested by %S.'],
+                ['browser:foobar' => 'Le site %S demande un nom d\'utilisateur et un mot de passe.'],
+                'release',
+                []
+            ],
+            [
+                // Variable format %S, different case (not an error)
+                ['browser:foobar' => 'A username and password are being requested by %S.'],
+                ['browser:foobar' => 'Le site %s demande un nom d\'utilisateur et un mot de passe.'],
+                'release',
+                []
+            ],
+            [
+                // Variable format %1$s
+                ['browser:foobar' => 'A username and password are being requested by %2$s. The site says: "%1$s"'],
+                ['browser:foobar' => 'Le site %2$s demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$s »'],
+                'release',
+                []
+            ],
+            [
+                // Variable format %1$s, different case (not an error)
+                ['browser:foobar' => 'Invalid section name (%1$s) at line %2$s.'],
+                ['browser:foobar' => 'Nom de section (%1$S) incorrect à la ligne %1$S.'],
+                'release',
+                []
+            ],
+            [
+                // Using ordered variables %1$S instead of %S (not an error)
+                ['browser:foobar' => 'Invalid section name (%1$S) at line %2$S.'],
+                ['browser:foobar' => 'Nom de section (%S) incorrect à la ligne %S.'],
+                'release',
+                []
+            ],
+            [
+                // Using %0.S instead of %S (not an error)
+                ['browser:foobar' => 'Do you want %S to save your tabs for the next time it starts?'],
+                ['browser:foobar' => 'Salvare le schede aperte per il prossimo avvio?%0.S'],
+                'release',
+                []
+            ],
+            [
+                // Using %1$0.S instead of %1$S (not an error)
+                ['browser:foobar' => '%1$S is unable to connect with %2$S right now.'],
+                ['browser:foobar' => 'Impossibile connettersi a %2$S in questo momento.%1$0.S'],
+                'release',
+                []
+            ],
+            [
+                // Mixed ordered variables %1$S and %S (error)
+                ['browser:foobar' => 'A username and password are being requested by %S. The site says: "%S"'],
+                ['browser:foobar' => 'Le site %S demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$S »'],
+                'release',
+                ['browser:foobar']
             ],
             [
                 // not matching test
                 ['foobar' => 'A username and password are being requested by %2$S. The site says: "%1$S"'],
                 ['foobar' => 'Le site %2$S demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$S »'],
-                ['/\s\$[a-z0-9\.]+\s/i'],
+                'release',
                 []
             ],
         ];


### PR DESCRIPTION
Two changes besides moving regexps into the class.

Modified the 'printf' regexp to find variables like %S, %1$S, but also $0.S and %1$0.S. Last two are zero-length strings, used as a hack to fool compare-locales and don't report missing variables.

For these variables, ignore case and:
- Check that string doesn't have a mix of ordered/unordered variables.
- Otherwise, if the total number of variables is the same, consider the string valid.
