### PR TITLE
Issue #340: better dev-setup.sh script and server start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ composer.lock
 composer.phar
 logs/*.log
 phpDocumentor.phar
-stats.json
+stats_locales.json
 stats_requests.json
 vendor
 web/assets

--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ The Transvision team uses Git and GitHub for both development and issue tracking
 3. Copy app/config/config.ini-dist to app/config/config.ini and adapt the variables to your system.
 4. Run first "app/scripts/setup.sh", then "app/scripts/glossaire.sh". This process will take some time as it downloads the source code for all Mozilla products (~20GB of data).
 5. Install Composer (Dependency Manager for PHP, http://getcomposer.org/) and run "php composer.phar install" (or "composer install" if installed globally) inside the web folder.
-6. You are set! You can run Transvision in your local machine with "php -S localhost:8080" inside the web/ folder and opening http://localhost:8080/ with your browser.
+6. You can run Transvision in your local machine either with the start.sh script or with "php -S localhost:8082 -t web/ app/inc/router.php" and opening http://localhost:8082/ with your browser.
 
 ## Snapshot installation (regular development)
 
 1. Fork the [Transvision Project][] into your GitHub account.
 2. Clone your fork to your machine.
 3. Copy app/config/config.ini-dev to app/config/config.ini and adapt the variables to your system.
-4. Run "app/scripts/dev-setup.sh". This process may take some time as it downloads a snapshot of data from Transvision server (~400MB). It will also download Composer, the PHP dependency manager, and install the dependencies needed.
-5. You are set! You can run Transvision in your local machine with "php -S localhost:8082 -t web/ app/inc/router.php" in your install folder and opening http://localhost:8082/ with your browser.
+4. Run "start.sh". This process may take some time as it downloads a snapshot of data from Transvision server (~400MB). It will also download Composer, the PHP dependency manager, and install the dependencies needed. Once this is done, PHP development server will be launched and you can visit http://localhost:8082/ with your browser.
+
+Note that if you launch start.sh again after the installation, it will not download again all the data, composer and dependencies, it will only launch the development server.
 
 ## Update glossary
 

--- a/app/config/config.ini-dev
+++ b/app/config/config.ini-dev
@@ -20,3 +20,6 @@ local_svn=/temp
 
 ; Only needed for production setup
 libraries=/temp
+
+; Flag to know if we are working in production more or development mode
+dev=true

--- a/app/config/config.ini-dist
+++ b/app/config/config.ini-dist
@@ -25,3 +25,6 @@ install=/home/pascalc/github/transvision
 
 ; Path to configuration files for Transvision
 config=/home/pascalc/repos/github/transvision/app/config
+
+; Flag to know if we are working in production more or development mode
+dev=false

--- a/app/config/config.ini-travis
+++ b/app/config/config.ini-travis
@@ -25,3 +25,6 @@ install=//home/travis/build/mozfr/transvision/github/
 
 ; Path to configuration files for Transvision
 config=/home/travis/build/mozfr/transvision/app/config
+
+; Flag to know if we are working in production more or development mode
+dev=true

--- a/app/inc/search_counter.php
+++ b/app/inc/search_counter.php
@@ -2,9 +2,9 @@
 namespace Transvision;
 
 // Create a JSON file logging locale/number of requests
-$stats = Json::fetch(WEB_ROOT . 'stats.json');
-$stats[$locale] = array_key_exists($locale, $stats) ?  $stats[$locale] += 1 : 1;
-file_put_contents(WEB_ROOT . 'stats.json', json_encode($stats));
+$stats = Json::fetch(WEB_ROOT . 'stats_locales.json');
+$stats[$locale] = array_key_exists($locale, $stats) ? $stats[$locale] += 1 : 1;
+file_put_contents(WEB_ROOT . 'stats_locales.json', json_encode($stats));
 
 // Create a JSON file logging search options to determine if some are unused
 $stats = Json::fetch(WEB_ROOT . 'stats_requests.json');

--- a/app/scripts/dev-setup.sh
+++ b/app/scripts/dev-setup.sh
@@ -23,23 +23,69 @@ function echogreen() {
     echo -e "$GREEN$*$NORMAL"
 }
 
-# Get server configuration variables
+# Store current directory path to be able to call the script from anywhere
 DIR=$(dirname "$0")
+
+# Check that we have a config.ini file
+if [ ! -f $DIR/../config/config.ini ]
+then
+    echo "ERROR: There is no app/config/config.ini file, please create it based on app/config/config.ini-dev before launching the dev-setup.sh script"
+    exit
+fi
+
+# Get server configuration variables
 source $DIR/iniparser.sh
 
-cd $root
-echogreen "Downloading a snapshot of data from Transvision Web site"
-wget http://transvision.mozfr.org/data.tar.gz -O - | tar -xz
-echogreen "Data is now extracted in your web/TMX/ folder"
+# Check that $install variable points to a git repo
+if [ ! -d $install/.git ]
+then
+    echo "ERROR: The 'install' variable in your config.ini file is probably wrong as there is no git repository at the location you provided."
+    exit
+fi
+
+# Check if we have a web/TMX folder in dev mode, if not download a data snapshot
+if $dev
+then
+    if [ ! -d $root/TMX ]
+    then
+        cd $root
+        echogreen "Downloading a snapshot of data from Transvision Web site"
+        wget http://transvision.mozfr.org/data.tar.gz -O - | tar -xz
+        echogreen "Data is now extracted in your web/TMX/ folder"
+    fi
+fi
 
 cd $install
-echogreen "Installing PHP dependencies with Composer"
-php -r "readfile('https://getcomposer.org/installer');" | php
-php composer.phar install
 
-echogreen "Add stats.json file"
-touch web/stats.json
+# Install Composer if missing
+if [ ! -f composer.phar ]
+then
+    echogreen "Installing Composer (PHP dependency manager)"
+    php -r "readfile('https://getcomposer.org/installer');" | php
+fi
+
+# Install PHP dependencies if not done yet
+if [ ! -d vendor ]
+then
+    echogreen "Installing PHP dependencies with Composer"
+    php composer.phar install
+fi
+
+# Create json files used for stats
+stats_file1=web/stats_locales.json
+stats_file2=web/stats_requests.json
+
+if [ ! -f $stats_file1 ]
+then
+    echogreen "Add $stats_file1 file"
+    echo '{}' > $stats_file1
+fi
+
+if [ ! -f $stats_file2 ]
+then
+    echogreen "Add $stats_file2 file"
+    echo '{}' > $stats_file2
+fi
 
 echogreen "Launching PHP development server (php -S localhost:8082 -t web/ app/inc/router.php)"
-cd $install
 php -S localhost:8082 -t web/ app/inc/router.php

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -308,5 +308,18 @@ if [ ! -d $install/web/download ]
 fi
 echo "AddType application/octet-stream .tmx" > $install/web/download/.htaccess
 
-echogreen "Add stats.json file"
-touch $install/web/stats.json
+# Create json files used for stats
+stats_file1=web/stats_locales.json
+stats_file2=web/stats_requests.json
+
+if [ ! -f $stats_file1 ]
+then
+    echogreen "Add $stats_file1 file"
+    echo '{}' > $stats_file1
+fi
+
+if [ ! -f $stats_file2 ]
+then
+    echogreen "Add $stats_file2 file"
+    echo '{}' > $stats_file2
+fi

--- a/app/views/stats.php
+++ b/app/views/stats.php
@@ -2,7 +2,7 @@
 namespace Transvision;
 
 // Get locales/number of requests
-$stats = Json::fetch(WEB_ROOT . 'stats.json');
+$stats = Json::fetch(WEB_ROOT . 'stats_locales.json');
 arsort($stats);
 
 echo '<table>';

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+./app/scripts/dev-setup.sh


### PR DESCRIPTION
- Abort the script if we don't have a config.ini file set up
- Check that the install folder is actually a git repo
- Download the TMX archive only if we don't have a web/TMX folder
- Download composer only if we don't already have it
- Install composer dependencies only if it is not already done
- Check if json files exist before creating them
- Rename stats.json as stats_locales.json
- Create a start.sh script at the root of the repo to set everything up and start the dev server
- New 'dev' variable in config.ini to indicate if we have a development install of a production install
