### PR TITLE
Issue # 348: remove {OK} strings in API calls

### DIFF
--- a/app/classes/Transvision/Strings.php
+++ b/app/classes/Transvision/Strings.php
@@ -26,31 +26,41 @@ class Strings
     }
 
     /**
-     * Check if $haystack starts with the $needle string
+     * Check if $haystack starts with a string in $needles.
+     * $needles can be a string or an array of strings.
      *
      * @param  string  $haystack String to analyse
-     * @param  string  $needle The string to look for
-     * @return boolean True if the strings starts with $needle
+     * @param  array   $needles  The string to look for
+     * @return boolean True if the $haystack string starts with a string in $needles
      */
-    public static function startsWith($haystack, $needle)
+    public static function startsWith($haystack, $needles)
     {
-        return !strncmp($haystack, $needle, mb_strlen($needle));
+        foreach((array) $needles as $prefix) {
+            if (! strncmp($haystack, $prefix, mb_strlen($prefix))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
-     * Check if $haystack ends with the $needle string
+     * Check if $haystack ends with a string in $needles.
+     * $needles can be a string or an array of strings.
      *
      * @param  string  $haystack String to analyse
-     * @param  string  $needle The string to look for
-     * @return boolean True if the strings ends with $needle
+     * @param  array   $needles The strings to look for
+     * @return boolean True if the $haystack string ends with a string in $needles
      */
-    public static function endsWith($haystack, $needle)
+    public static function endsWith($haystack, $needles)
     {
-        if (mb_strlen($needle) == 0) {
-            return true;
+        foreach((array) $needles as $suffix) {
+            if (mb_substr($haystack, -mb_strlen($suffix)) === $suffix) {
+                return true;
+            }
         }
 
-        return mb_substr($haystack, -mb_strlen($needle)) === $needle;
+        return false;
     }
 
     /**

--- a/app/models/api/entity.php
+++ b/app/models/api/entity.php
@@ -18,7 +18,7 @@ if (! $translations = Cache::getKey($cache_id)) {
 
         if (isset($strings[$entity])) {
             $strings[$entity] = trim($strings[$entity]);
-            if (Strings::endsWith($strings[$entity], '{ok}')) {
+            if (Strings::endsWith(strtolower($strings[$entity]), '{ok}')) {
                 $strings[$entity] = trim(substr($strings[$entity], 0, -4));
             }
             $translations[$locale_code] = $strings[$entity];
@@ -30,5 +30,4 @@ if (! $translations = Cache::getKey($cache_id)) {
 
    Cache::setKey($cache_id, $translations);
 }
-
 return $json = $translations;

--- a/tests/units/Transvision/Strings.php
+++ b/tests/units/Transvision/Strings.php
@@ -28,7 +28,9 @@ class Strings extends atoum\test
     {
         return [
             ['it is raining', 'it', true],
-            [' foobar starts with a nasty space', 'foobar', false]
+            [' foobar starts with a nasty space', 'foobar', false],
+            ['multiple matches test', ['horse', 'multiple'], true],
+            ['multiple matches test', ['not', 'there'], false],
         ];
     }
 
@@ -47,7 +49,9 @@ class Strings extends atoum\test
     {
         return [
             ['it is raining', 'ing', true],
-            ['foobar ends with a nasty space ', 'space', false]
+            ['foobar ends with a nasty space ', 'space', false],
+            ['multiple matches test', ['horse', 'test'], true],
+            ['multiple matches test', ['not', 'there'], false],
         ];
     }
 


### PR DESCRIPTION
- Remove all capitalization variants of {ok}
- Update Strings::endsWith() and Strings::startsWith() to accept arrays of strings
