### PR TITLE
Issues 305: don't overescape strings at extraction time

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -258,10 +258,14 @@ class ShowResults
                 }
             }
 
+            // Escape HTML before highlighing search terms
+            $source_string = htmlspecialchars($source_string);
+            $target_string = htmlspecialchars($target_string);
             $source_string = Utils::highlightString($source_string);
             $target_string = Utils::highlightString($target_string);
 
             if (isset($search_options["extra_locale"])) {
+                $target_string2 = htmlspecialchars($target_string2);
                 $target_string2 = Utils::highlightString($target_string2);
             }
 
@@ -354,7 +358,6 @@ class ShowResults
             } else {
                 $extra_column_rows = '';
             }
-
             $table .= "
                 <tr class='{$component}'>
                   <td>
@@ -374,10 +377,11 @@ class ShowResults
                       </a>
                       <span>Translate with:</span>
                       <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
-                      . urlencode(strip_tags($source_string))
+                      // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
                       . "' target='_blank'>Google</a>
                       <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
-                      . urlencode(strip_tags($source_string))
+                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
                       . "' target='_blank'>BING</a>
                     </div>
                   </td>

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -237,23 +237,24 @@ class Utils
     }
 
     /**
-     * Sanitize and clean up for "noise" a string
+     * Clean up for "noise" a string
      *
-     * @param string $str the string to clean up
-     * @return string the cleaned up string
+     * @param  string $string the string to clean up
+     * @return string The cleaned up string
      */
-    public static function cleanSearch($str)
+    public static function cleanString($string)
     {
-        if (!is_string($str)) {
+        if (! is_string($string)) {
             return '';
         }
 
-        $str = self::secureText($str);
-        $str = stripslashes($str);
-        // Filter out double spaces
-        $str = Strings::mtrim($str);
+        // Remove escaped characters (quotes)
+        $string = stripslashes($string);
 
-        return $str;
+        // Filter out double spaces
+        $string = Strings::mtrim($string);
+
+        return $string;
     }
 
     /**

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -25,7 +25,7 @@ if (isset($_GET['json'])) {
         escaped slashes, it gives a 404 instead of going through mod_rewrite
         see: http://www.leakon.com/archives/865
      */
-    $terms = urlencode(urlencode(Utils::secureText($_GET['recherche'])));
+    $terms = urlencode(urlencode(Utils::cleanString($_GET['recherche'])));
 
     $regex = [];
     $regex['whole']   = isset($_GET['whole_word']) ? 'whole_word=1' : '';

--- a/app/inc/mozorg.php
+++ b/app/inc/mozorg.php
@@ -34,7 +34,7 @@ foreach (Files::getFilenamesInFolder( SVN . 'mozilla_org/') as $locale) {
                     "'"
                    . Dotlang::generateStringID('mozilla_org/' . $file, $str1)
                    . "' => '"
-                   . Utils::secureText($str2)
+                   . str_replace("'", "\\'", $str2)
                    . "',"
                    . "\n";
 

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 // Default search value
 $_GET['recherche'] = isset($_GET['recherche']) ? $_GET['recherche'] : '';
-$my_search = Utils::cleanSearch($_GET['recherche']);
+$my_search = Utils::cleanString($_GET['recherche']);
 
 // Cloned value for reference
 $initial_search = $my_search;

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -10,7 +10,7 @@ $get_option = function($option) use ($request) {
 };
 
 // Get all strings
-$initial_search = urldecode(Utils::cleanSearch($request->parameters[6]));
+$initial_search = urldecode(Utils::cleanString($request->parameters[6]));
 $source_strings = Utils::getRepoStrings($request->parameters[4], $request->parameters[3]);
 
 // Regex options

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -6,7 +6,7 @@ $source_strings = Utils::getRepoStrings($request->parameters[3], $request->param
 $target_strings = Utils::getRepoStrings($request->parameters[4], $request->parameters[2]);
 
 // The search
-$initial_search = Utils::cleanSearch($request->parameters[5]);
+$initial_search = Utils::cleanString($request->parameters[5]);
 $terms = Utils::uniqueWords($initial_search);
 
 // Regex options (not currenty used)

--- a/app/scripts/tmxmaker.py
+++ b/app/scripts/tmxmaker.py
@@ -25,18 +25,12 @@ import silme.io
 silme.format.Manager.register('dtd', 'properties', 'ini', 'inc')
 
 def escape(t):
-    """HTML-escape the text in `t`. We first hide real common entities to avoid double escaping"""
-    return (t
-        .replace("&quot;", '@quot;')
-        .replace("&amp;", "@amp;").replace("&lt;", "@lt;").replace("&gt;", "@gt;")
-
-        .replace("&", "&amp;").replace("<", "&#60;").replace(">", "&#62;")
-        .replace("'", "&#39;").replace('"', "&#34;")
-        .replace("\\", "&#92;")
-
-        .replace("@quot;", '&#34;')
-        .replace("@amp;", "&amp;").replace("@lt;", "&#60;").replace("@gt;", "&#62;")
-
+    """Escape quotes in `t`. Complicated replacements because some strings are already escaped in the repo"""
+    return (t.replace("\\'", '_qu0te_')
+        .replace("\\", "_sl@sh_")
+        .replace("'", "\\'")
+        .replace('_qu0te_', "\\'")
+        .replace('_sl@sh_', '\\\\')
         )
 
 def get_string(package, localdirectory):

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -150,7 +150,7 @@ class Utils extends atoum\test
                 ->isEqualTo('<option value=strings>Strings</option><option value=entities>Entities</option><option selected value=strings_entities>Strings & Entities</option>');
     }
 
-    public function cleanSearchDP()
+    public function cleanStringDP()
     {
         return [
             [
@@ -160,18 +160,22 @@ class Utils extends atoum\test
             [
                 'toto ',
                 'toto'
-            ]
+            ],
+            [
+                'don\'t escape',
+                "don't escape"
+            ],
         ];
     }
 
     /**
-     * @dataProvider cleanSearchDP
+     * @dataProvider cleanStringDP
      */
-    public function testCleanSearch($a, $b)
+    public function testCleanString($a, $b)
     {
         $obj = new _Utils();
         $this
-            ->string($obj->cleanSearch($a))
+            ->string($obj->cleanString($a))
                 ->isEqualTo($b);
     }
 


### PR DESCRIPTION
- We now only escape single quotes at extractions and leave other special characters alone (&<>")
- We escape special characters at display time
- Utils::cleanSearch() renamed to Utils::cleanString() and no longer sanitize strings for security (use Utils::secureText())
- Searches for special characters such as &brandshortname; or \ now work, same for API
- Google and Bing links no longer include html entities
