### PR TITLE
Fix glossaire (missing folders) and setup (stats files)

### DIFF
--- a/app/scripts/glossaire.sh
+++ b/app/scripts/glossaire.sh
@@ -87,11 +87,16 @@ function updateStandardRepo() {
             cd ${!repo_l10n}            # value of variable called repo_l10n, e.g. value of $release_l10n
             for locale in $(cat ${!locale_list})
             do
-                echogreen "Update $repo_name/$locale"
-                cd $locale
-                hg pull -r default
-                hg update -C
-                cd ..
+                if [ -d ${!repo_l10n}/$locale ]
+                then
+                    echogreen "Update $repo_name/$locale"
+                    cd $locale
+                    hg pull -r default
+                    hg update -C
+                    cd ..
+                else
+                    echored "Folder ${!repo_l10n}/$locale does not exist. Run setup.sh to fix the issue."
+                fi
             done
         else
             if [ -d ${!repo_l10n}/$locale_code ]
@@ -166,11 +171,16 @@ function updateGaiaRepo() {
             cd ${!repo_name}
             for locale in $(cat ${!locale_list})
             do
-                echogreen "Update $repo_name/$locale"
-                cd $locale
-                hg pull -r default
-                hg update -C
-                cd ..
+                if [ -d ${!repo_l10n}/$locale ]
+                then
+                    echogreen "Update $repo_name/$locale"
+                    cd $locale
+                    hg pull -r default
+                    hg update -C
+                    cd ..
+                else
+                    echored "Folder ${!repo_l10n}/$locale does not exist. Run setup.sh to fix the issue."
+                fi
             done
         else
             if [ -d ${!repo_name}/$locale_code ]

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -36,7 +36,7 @@ folders=( $release_source $beta_source $aurora_source $trunk_source \
 echogreen "Creating folders..."
 for folder in "${folders[@]}"
 do
-  mkdir -p "$folder"
+    mkdir -p "$folder"
 done
 
 function createSymlinks() {
@@ -309,17 +309,14 @@ fi
 echo "AddType application/octet-stream .tmx" > $install/web/download/.htaccess
 
 # Create json files used for stats
-stats_file1=web/stats_locales.json
-stats_file2=web/stats_requests.json
+stats_files=( $install/web/stats_locales.json
+              $install/web/stats_requests.json )
 
-if [ ! -f $stats_file1 ]
-then
-    echogreen "Add $stats_file1 file"
-    echo '{}' > $stats_file1
-fi
-
-if [ ! -f $stats_file2 ]
-then
-    echogreen "Add $stats_file2 file"
-    echo '{}' > $stats_file2
-fi
+for stats_file in "${stats_files[@]}"
+do
+    if [ ! -f $stats_file ]
+    then
+        echogreen "Add $stats_file file"
+        echo '{}' > $stats_file
+    fi
+done


### PR DESCRIPTION
**glossaire.sh**
If a folder is missing, all next locales won’t be updated because we’re in the wrong folder

**setup.sh**
Needs an absolute path for the .json files. Also switch to array instead of having two identical pieces of code
