### PR TITLE
Issue #381:

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -352,9 +352,7 @@ class ShowResults
                         &lt;report a bug&gt;
                       </a>
                     </div>
-                  </td>
-                </tr>";
-
+                  </td>";
             } else {
                 $extra_column_rows = '';
             }

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -1,14 +1,14 @@
 <?php
 namespace Transvision;
 
-
-$table  = "<table class='collapsable'>
-              <tr>
-                <th>Entity</th>
-                <th>{$source_locale}</th>
-                <th>{$locale}</th>
-                {$extra_column_header}
-              </tr>";
+$table = "
+<table class='collapsable'>
+  <tr>
+    <th>Entity</th>
+    <th>{$source_locale}</th>
+    <th>{$locale}</th>
+    {$extra_column_header}
+  </tr>";
 
 // Display results
 foreach ($entities as $entity) {
@@ -21,7 +21,6 @@ foreach ($entities as $entity) {
     }
 
     if ($url['path'] == '3locales') {
-
         if (isset($tmx_target2[$entity])) {
             // nbsp highlight
             $target_string2 = str_replace(' ', '<span class="highlight-gray"> </span>', $tmx_target2[$entity]);
@@ -34,7 +33,6 @@ foreach ($entities as $entity) {
         } else {
             $path_locale3 = VersionControl::hgPath($locale2, $check['repo'], $entity);
         }
-
     }
 
     if (isset($tmx_target[$entity])) {
@@ -44,7 +42,10 @@ foreach ($entities as $entity) {
         $target_string = '';
     }
 
-    $source_string = $tmx_source[$entity];
+    // Escape strings for HTML Display
+    $source_string  = Utils::secureText($tmx_source[$entity]);
+    $target_string  = Utils::secureText($target_string);
+    $target_string2 = Utils::secureText($target_string2);
 
     // 3locales view
     if ($url['path'] == '3locales') {
@@ -60,17 +61,14 @@ foreach ($entities as $entity) {
                   . '">&lt;report a bug&gt;</a>';
 
         $extra_column_rows = "
-        <td dir='{$direction3}'>
-            <span class='celltitle'>{$locale3}</span>
-            <div class='string'>{$target_string2}</div>
-            <div dir='ltr' class='infos'>
-              <a class='source_link' href='{$path_locale3}'>
-                <em>&lt;source&gt;</em>
-              </a>
-              {$file_bug}
-            </div>
-          </td>
-        </tr>";
+    <td dir='{$direction3}'>
+      <span class='celltitle'>{$locale2}</span>
+      <div class='string'>{$target_string2}</div>
+      <div dir='ltr' class='infos'>
+        <a class='source_link' href='{$path_locale3}'><em>&lt;source&gt;</em></a>
+        {$file_bug}
+      </div>
+    </td>";
 
     } else {
         $extra_column_rows = '';
@@ -87,31 +85,33 @@ foreach ($entities as $entity) {
                                           $target_string, $check['repo'], $entity_link)
               . '">&lt;report a bug&gt;</a>';
     $anchor_name = str_replace(array('/', ':'), '_', $entity);
-    $table .= "<tr>
-                    <td>
-                    <span class='celltitle'>Entity</span>
-                    <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
-                    <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$check['repo']}' title='List all translations for this entity'>l10n</a>
-                    <a class='linktoentity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $my_search) . "</a></td>
-                    <td dir='{$direction1}'>
-                       <span class='celltitle'>{$source_locale}</span>
-                       <div class='string'>{$source_string}</div>
-                       <div dir='ltr' class='infos'>
-                        <a class='source_link' href='{$path_locale1}'><em>&lt;source&gt;</em></a>
-                       </div>
-                    </td>
-                     <td dir='{$direction2}'>
-                       <span class='celltitle'>{$locale}</span>
-                       <div class='string'>{$target_string}</div>
-                       <div dir='ltr' class='infos'>
-                        <a class='source_link' href='{$path_locale2}'><em>&lt;source&gt;</em></a>
-                        {$file_bug}
-                       </div>
-                    </td>
-                {$extra_column_rows}
-                </tr>";
+    $table .= "
+  <tr>
+    <td>
+      <span class='celltitle'>Entity</span>
+      <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
+      <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$check['repo']}' title='List all translations for this entity'>l10n</a>
+      <a class='linktoentity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $my_search) . "</a>
+    </td>
+    <td dir='{$direction1}'>
+      <span class='celltitle'>{$source_locale}</span>
+      <div class='string'>{$source_string}</div>
+      <div dir='ltr' class='infos'>
+        <a class='source_link' href='{$path_locale1}'><em>&lt;source&gt;</em></a>
+      </div>
+    </td>
+    <td dir='{$direction2}'>
+      <span class='celltitle'>{$locale}</span>
+      <div class='string'>{$target_string}</div>
+      <div dir='ltr' class='infos'>
+        <a class='source_link' href='{$path_locale2}'><em>&lt;source&gt;</em></a>
+        {$file_bug}
+      </div>
+    </td>
+    {$extra_column_rows}
+  </tr>\n";
 }
 
-$table .= "  </table>\n\n";
+$table .= "</table>\n\n";
 
 print $table;


### PR DESCRIPTION
- escape html in result strings in entities view
- also fixes bad html in table generation for both string and entities searches
- fix a wrong variable name causing a missing header in mobile display + a warning
- whitespace changes
