### PR TITLE
Improve "Unchanged String" view

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -201,7 +201,7 @@ class ShowResults
         }
 
         $table  = "<table class='collapsable'>
-                      <tr>
+                      <tr class='column_headers'>
                         <th>Entity</th>
                         <th>{$locale1}</th>
                         <th>{$locale2}</th>

--- a/app/models/unchanged_strings.php
+++ b/app/models/unchanged_strings.php
@@ -33,8 +33,11 @@ foreach ($strings_reference as $string_id => $string_value) {
 // Find strings identical to English
 $unchanged_strings = [];
 foreach ($strings_reference as $string_id => $string_value) {
-    if ($strings_locale[$string_id] == $string_value) {
-        $unchanged_strings[$string_id] = $string_value;
+    if (isset($strings_locale[$string_id])) {
+        // Compare only if the localized string exists
+        if ($strings_locale[$string_id] == $string_value) {
+            $unchanged_strings[$string_id] = $string_value;
+        }
     }
 }
 

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -20,12 +20,11 @@ foreach ($entities as $entity) {
         $path_locale2 = VersionControl::hgPath($locale, $check['repo'], $entity);
     }
 
+    $target_string2 = '';
     if ($url['path'] == '3locales') {
         if (isset($tmx_target2[$entity])) {
             // nbsp highlight
             $target_string2 = str_replace(' ', '<span class="highlight-gray"> </span>', $tmx_target2[$entity]);
-        } else {
-            $target_string2 = '';
         }
 
         if ($check['repo'] == 'mozilla_org') {

--- a/app/views/unchanged_strings.php
+++ b/app/views/unchanged_strings.php
@@ -15,22 +15,30 @@ if(isset($filter_block)) {
 }
 
 $content .= "<table class='collapsable'>\n";
-$content .= "  <thead>\n" .
-            "    <tr>\n" .
-            "      <th>String ID</th>\n" .
-            "      <th>English</th>\n" .
-            "      <th>Translation</th>\n" .
-            "    </tr>\n" .
-            "  </thead>\n" .
-            "  <tbody>\n";
+$content .= "  <tr class='column_headers'>\n" .
+            "    <th>String ID</th>\n" .
+            "    <th>English</th>\n" .
+            "    <th>Translation</th>\n" .
+            "  </tr>\n";
 foreach ($unchanged_strings as $string_id => $string_value) {
     $component = explode('/', $string_id)[0];
-    $content .= "    <tr class='{$component}'>\n" .
-                "      <td>{$string_id}</td>\n" .
-                "      <td>{$string_value}</td>\n" .
-                "      <td>" . $strings_locale[$string_id] ."</td>\n" .
-                "    </tr>\n";
+
+    $entity_link = "/?sourcelocale={$source_locale}"
+            . "&locale={$locale}"
+            . "&repo={$repo}"
+            . "&search_type=entities&recherche={$string_id}";
+
+    /* Since this view displays strings identical to source locale, I'll use the same
+     * direction, not the locale's default (for example I'll use LTR for English+Arabic).
+     */
+    $direction = RTLSupport::getDirection($source_locale);
+
+    $content .= "  <tr class='{$component}'>\n" .
+                "    <td dir='ltr'><a href='{$entity_link}'>{$string_id}</a></td>\n" .
+                "    <td dir='{$direction}' lang='{$source_locale}'>{$string_value}</td>\n" .
+                "    <td dir='{$direction}' lang='{$locale}'>" . $strings_locale[$string_id] ."</td>\n" .
+                "  </tr>\n";
 }
-$content .= "  </tbody>\n</table>\n";
+$content .= "</table>\n";
 
 echo $content;

--- a/web/js/component_filter.js
+++ b/web/js/component_filter.js
@@ -8,6 +8,8 @@ $(document).ready(function() {
         } else {
             $('tr').hide();
             $('.' + e.target.id).show();
+            // Always show column headers
+            $('.column_headers').show();
             $('#' + e.target.id).addClass('selected');
         }
     });


### PR DESCRIPTION
- Fixed styling of first row of results
- Make column headers visible even when a component is filtered
- Added dir and lang attributes to rows
- Added links in the first column, but not the usual style to keep row height smaller

"Unchanged strings" model:
- Don't try to compare strings missing in locale

Fixed undefined var $target_string2 warning in views/results_entities.php
