### PR TITLE
Smarter locale selection in searches

### DIFF
--- a/app/classes/Transvision/Project.php
+++ b/app/classes/Transvision/Project.php
@@ -217,8 +217,8 @@ class Project
             'es-CL' => 'es',
             'es-ES' => 'es',
             'es-MX' => 'es',
-            'gu-in' => 'gu',
-            'pa-in' => 'pa',
+            'gu-IN' => 'gu',
+            'pa-IN' => 'pa',
             'sr'    => 'sr-Cyrl',
         ];
 

--- a/app/inc/l10n-init.php
+++ b/app/inc/l10n-init.php
@@ -16,17 +16,14 @@ if (isset($_GET['repo'])) {
 
 $all_locales = Project::getRepositoryLocales($repo);
 
-// Add en-US as a regular locale without impacting glossaire.sh
-$all_locales[] = 'en-US';
-
 $l10n = new \tinyl10n\ChooseLocale($all_locales);
 $l10n->setDefaultLocale('fr');
 $l10n->mapLonglocales = true;
 $locale = $l10n->getCompatibleLocale();
 $locale2 = $locale;
-$source_locale = 'en-US';
+$source_locale = Project::getReferenceLocale($repo);
 
-// Bypass locale & source locale detection if there are a COOKIES stored with them
+// Bypass locale & source locale detection if there are COOKIES stored with them
 if (isset($_COOKIE['default_source_locale'])) {
     $source_locale = $_COOKIE['default_source_locale'];
 }
@@ -41,21 +38,34 @@ if (isset($_COOKIE['default_target_locale2'])) {
 }
 
 // Bypass locale detection if the page sends a valid GET variable
-if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
-    $l10n->setDefaultLocale($_GET['locale']);
-    $locale = $l10n->getDefaultLocale();
+if (isset($_GET['locale'])) {
+    // Redirect locale to a different one if necessary
+    $requested_locale = $_GET['locale'];
+    $requested_locale = Project::getLocaleInContext($requested_locale, $repo);
+    if (in_array($requested_locale, $all_locales)) {
+        $l10n->setDefaultLocale($requested_locale);
+        $locale = $l10n->getDefaultLocale();
+    }
 }
 
-// Bypass locale2 default value or cookie if the page sends a valid GET variable
-if (isset($_GET['locale2']) && in_array($_GET['locale2'], $all_locales)) {
-    $locale2 = $_GET['locale2'];
+// Bypass locale detection if the page sends a valid GET variable
+if (isset($_GET['locale2'])) {
+    // Redirect locale to a different one if necessary
+    $requested_locale2 = $_GET['locale2'];
+    $requested_locale2 = Project::getLocaleInContext($requested_locale2, $repo);
+    if (in_array($requested_locale2, $all_locales)) {
+        $locale2 = $requested_locale2;
+    }
 }
 
 // Bypass default source locale for locale to locale comparison
-if (isset($_GET['sourcelocale']) && $_GET['sourcelocale'] == 'en-US') {
-    $source_locale = 'en-US';
-} elseif (isset($_GET['sourcelocale']) && in_array($_GET['sourcelocale'], $all_locales)) {
-    $source_locale = $_GET['sourcelocale'];
+if (isset($_GET['sourcelocale'])) {
+    // Redirect locale to a different one if necessary
+    $requested_sourcelocale = $_GET['sourcelocale'];
+    $requested_sourcelocale = Project::getLocaleInContext($requested_sourcelocale, $repo);
+    if (in_array($requested_sourcelocale, $all_locales)) {
+        $source_locale = $requested_sourcelocale;
+    }
 }
 
 // Get rtl attribute for source and target locales

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -70,14 +70,20 @@ foreach ($repositories as $repository) {
     // build the source locale switcher
     $source_locales_list[$repository] = Utils::getHtmlSelectOptions(
         $loc_list[$repository],
-        Project::getReferenceLocale($repository)
+        Project::getLocaleInContext($source_locale, $repository)
     );
 
     // build the target locale switcher
-    $target_locales_list[$repository] = Utils::getHtmlSelectOptions($loc_list[$repository], $locale);
+    $target_locales_list[$repository] = Utils::getHtmlSelectOptions(
+        $loc_list[$repository],
+        Project::getLocaleInContext($locale, $repository)
+    );
 
     // 3locales view: build the target locale switcher for a second locale
-    $target_locales_list2[$repository] = Utils::getHtmlSelectOptions($loc_list[$repository], $locale2);
+    $target_locales_list2[$repository] = Utils::getHtmlSelectOptions(
+        $loc_list[$repository],
+        Project::getLocaleInContext($locale2, $repository)
+    );
 }
 
 // Build the search type switcher


### PR DESCRIPTION
Current issues
- We currently lose the source locale after a search (reset to reference locale)
- If I’m searching for es-ES, and switch to Gaia, es is not automatically selected.

This also fixed #103 
