### PR TITLE
Issue #413: Use Symfony var_dumper() function instead of Kint.

### DIFF
--- a/app/helpers/debug.php
+++ b/app/helpers/debug.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Utility function to get symfony dump() function output to the CLI
+ * http://symfony.com/doc/current/components/var_dumper/
+ */
+function cli_dump() {
+    $cloner = new Symfony\Component\VarDumper\Cloner\VarCloner();
+    $dumper = new Symfony\Component\VarDumper\Dumper\CliDumper();
+    foreach (func_get_args() as $arg) {
+        $dumper->dump($cloner->cloneVar($arg));
+    }
+}

--- a/app/inc/init.php
+++ b/app/inc/init.php
@@ -1,5 +1,5 @@
 <?php
-use raveren\klint;
+use Symfony\VarDumper;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
@@ -24,9 +24,6 @@ require_once __DIR__ . '/variables.php';
 // For debugging
 if (DEBUG) {
     error_reporting(E_ALL);
-    kint::enabled(true);
-} else {
-    kint::enabled(false);
 }
 
 // Logging

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,12 @@
         "components/jquery": "1.11.*",
         "monolog/monolog" : "1.10.0",
         "pascalc/tinyl10n" : "0.6",
-        "pascalc/vcs": "0.4"
-    },
-
-    "require-dev": {
-        "raveren/kint" : "dev-1.0.0-wip"
+        "pascalc/vcs": "0.4",
+        "symfony/var-dumper": "~2.6"
     },
 
     "autoload": {
-        "psr-0": {"Transvision": "app/classes/"}
+        "psr-0": {"Transvision": "app/classes/"},
+        "files": ["app/helpers/debug.php"]
     }
 }


### PR DESCRIPTION
http://symfony.com/doc/current/components/var_dumper/
- new dump() function, outputs structured elements to the SAPI (the web page if called from the web, the console if called from a script)
- helper function cli_dump() added, allows outputing debug info to the CLI from a web page
- new app/helpers folder for such functions
- app/helpers/debug.php autoloaded via composer
