### PR TITLE
Use Aurora as default, reorganize Javascript to manage cookies, locale lists, defaults

### DIFF
--- a/app/inc/l10n-init.php
+++ b/app/inc/l10n-init.php
@@ -7,10 +7,10 @@ namespace Transvision;
 if (isset($_GET['repo'])) {
     $repo = Project::isValidRepository($_GET['repo'])
             ? $_GET['repo']
-            : 'central';
+            : 'aurora';
 } else {
     if (! isset($repo)) {
-        $repo = 'central';
+        $repo = 'aurora';
     }
 }
 
@@ -71,3 +71,6 @@ if (isset($_GET['sourcelocale'])) {
 // Get rtl attribute for source and target locales
 $locale_dir = $l10n->getDirection($locale);
 $source_locale_dir = $l10n->getDirection($source_locale);
+
+// Initialize list of JavaScript files to include
+$javascript_include = [];

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -100,7 +100,7 @@ $search_type_list = Utils::getHtmlSelectOptions(
 );
 
 // Get COOKIES
-$get_cookie = function($var) {
+$get_cookie = function ($var) {
     return isset($_COOKIE[$var]) ? $_COOKIE[$var] : '';
 };
 

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -82,7 +82,7 @@ if (! $search_yields_results) {
 } else {
     if (in_array($check['repo'], $desktop_repos)) {
         // Build logic to filter components
-        $javascript_include = ['component_filter.js'];
+        $javascript_include[] = 'component_filter.js';
         $filter_block = '';
         foreach ($components as $value) {
             $filter_block .= " <a href='#{$value}' id='{$value}' class='filter'>{$value}</a>";

--- a/app/views/accesskeys.php
+++ b/app/views/accesskeys.php
@@ -3,19 +3,6 @@ namespace Transvision;
 
 require_once INC . 'l10n-init.php';
 
-// let's add en-US to check their errors too
-$all_locales[] = 'en-US';
-
-$repo = 'central';
-
-if (isset($_GET['repo']) && in_array($_GET['repo'], $desktop_repos)) {
-    $repo = $_GET['repo'];
-}
-
-if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
-    $locale = $_GET['locale'];
-}
-
 $strings[$repo]        = Utils::getRepoStrings($locale, $repo);
 $strings_english[$repo] = Utils::getRepoStrings('en-US', $repo);
 

--- a/app/views/channelcomparison.php
+++ b/app/views/channelcomparison.php
@@ -14,10 +14,6 @@ if (isset($_GET['chan2']) && in_array($_GET['chan2'], $desktop_repos)) {
     $chan2 = $_GET['chan2'];
 }
 
-if (isset($_GET['locale']) && in_array($_GET['locale'], $all_locales)) {
-    $locale = $_GET['locale'];
-}
-
 $strings = array();
 $strings[$chan1] = Utils::getRepoStrings($locale, $chan1);
 $strings[$chan2] = Utils::getRepoStrings($locale, $chan2);

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -1,5 +1,9 @@
 <?php
 namespace Transvision;
+
+// Include external JavaScript
+$javascript_include[] = 'main_search.js';
+
 ?>
   <div id="current">You are looking at the <em><?=$repos_nice_names[$check['repo']]?></em> channel <strong><?=$locale?></strong></div>
     <form name="searchform" id="searchform" method="get" action="./" >
@@ -23,16 +27,14 @@ namespace Transvision;
                     <select
                         id='repository'
                         name='repo'
-                        onchange="changeSourceTargetValues(this.value);"
                         title="Repository">
                     <?=$repo_list?>
                     </select>
                     <label class="default_option" for="default_repository">
                         <input type="checkbox"
                                id="default_repository"
-                               value="<?=$check['repo']?>"
-                               data-cookie="<?=$cookie_repository?>"
-                               onclick="setCookie('default_repository',this.value,3650);"
+                               class="mainsearch_default_checkbox"
+                               value="<?=$cookie_repository?>"
                                <?=Utils::checkboxDefaultOption($check['repo'], $cookie_repository)?>
                          /> <span>Default</span>
                      </label>
@@ -42,16 +44,15 @@ namespace Transvision;
                     <select
                         id='source_locale'
                         name='sourcelocale'
-                        onchange="changeDefaultSource('source_locale');"
+                        class='mainsearch_locale_selector'
                         title="Source Locale">
                     <?=$source_locales_list[$check['repo']]?>
                     </select>
                     <label class="default_option" for="default_source_locale">
                         <input type="checkbox"
                                id="default_source_locale"
-                               value="<?=$source_locale?>"
-                               data-cookie="<?=$cookie_source_locale?>"
-                               onclick="setCookie('default_source_locale',this.value,3650);"
+                               class="mainsearch_default_checkbox"
+                               value="<?=$cookie_source_locale?>"
                                 <?php
                                 // Mark as default only if the cookie_source_locale exist in repository array
                                 if (in_array($cookie_source_locale, $loc_list[$check['repo']])) {
@@ -66,16 +67,15 @@ namespace Transvision;
                     <select
                         id='target_locale'
                         name='locale'
-                        onchange="changeDefaultSource('target_locale');"
+                        class='mainsearch_locale_selector'
                         title="Target Locale">
                     <?=$target_locales_list[$check['repo']]?>
                     </select>
                     <label class="default_option" for="default_target_locale">
                         <input type="checkbox"
                                id="default_target_locale"
-                               value="<?=$locale?>"
-                               data-cookie="<?=$cookie_target_locale?>"
-                               onclick="setCookie('default_target_locale',this.value,3650);"
+                               class="mainsearch_default_checkbox"
+                               value="<?=$cookie_target_locale?>"
                                 <?php
                                 // Mark as default only if the cookie_target_locale exist in repository array
                                 if (in_array($cookie_target_locale, $loc_list[$check['repo']])) {
@@ -92,16 +92,15 @@ namespace Transvision;
                     <select
                         id='target_locale2'
                         name='locale2'
-                        onchange="changeDefaultSource('target_locale2');"
+                        class='mainsearch_locale_selector'
                         title="Extra Locale">
                     <?=$target_locales_list2[$check['repo']]?>
                     </select>
                     <label class="default_option" for="default_target_locale2">
                         <input type="checkbox"
                                id="default_target_locale2"
-                               value="<?=$locale2?>"
-                               data-cookie="<?=$cookie_target_locale2?>"
-                               onclick="setCookie('default_target_locale2',this.value,3650);"
+                               class="mainsearch_default_checkbox"
+                               value="<?=$cookie_target_locale2?>"
                                 <?php
                                 // Mark as default only if the cookie_target_locale exist in repository array
                                 if (in_array($cookie_target_locale2, $loc_list[$check['repo']])) {
@@ -118,7 +117,6 @@ namespace Transvision;
                     <select
                         name='search_type'
                         id='search_type'
-                        onchange="changeSearchContext(this);"
                         title="Search in">
                     <?=$search_type_list?>
                     </select>
@@ -168,7 +166,7 @@ namespace Transvision;
                            name="t2t"
                            id="t2t"
                            value="t2t"
-                           <?=Utils::checkboxState($check['t2t'], 't2t')?> onclick="uncheckAll();"
+                           <?=Utils::checkboxState($check['t2t'], 't2t')?>
                     />
                     <?php endif; ?>
                 </fieldset>
@@ -176,82 +174,3 @@ namespace Transvision;
             <p id="displaysearchoptions" class="smallscreen_notices"><a class="toggle-searchoptions-link" href="">⇓ Display search options ⇓</a></p>
         </fieldset>
  </form>
-
-<script>
-function uncheckAll() {
-    var arr = [<?php
-        $count_form_checkboxes = 0;
-        foreach ($form_checkboxes as $v) {
-            $end  = ($count_form_checkboxes == count($form_checkboxes) - 1) ? '' : ', ';
-            echo "'" . $v . "'" . $end;
-            $count_form_checkboxes++;
-        }
-    ?>];
-    for (var i = 0; i < arr.length; i++) {
-        el = document.getElementById(arr[i]);
-        if (el.disabled) {
-            el.removeAttribute('checked');
-        } else {
-            el.setAttribute('checked', 'checked');
-        }
-    }
-}
-function uncheck(val1, val2) {
-    source = document.getElementById(val1);
-    target = document.getElementById(val2);
-    if (source.checked == true) {
-        target.checked = false;
-    }
-}
-//Change related imput value and check if default
-function changeDefaultSource(selector) {
-    var selectValue = document.getElementById(selector).value;
-    var defaultInput = document.getElementById('default_' + selector);
-    defaultInput.value = selectValue;
-    if (defaultInput.value == defaultInput.getAttribute('data-cookie')) {
-        defaultInput.checked = true;
-    } else {
-        defaultInput.checked = false;
-    }
-}
-//Set Cookie to store default value
-function setCookie(cookieName,cookieValue,nDays) {
-    var today = new Date();
-    var expire = new Date();
-    var defaultInput = document.getElementById(cookieName);
-    if(!defaultInput.checked) {
-        //Input un-checked -> Delete cookie
-        cookieValue = '';
-        nDays = 0;
-    }
-    expire.setTime(today.getTime() + 3600000*24*nDays);
-    document.cookie = cookieName + '=' + escape(cookieValue) + ';expires=' + expire.toGMTString();
-}
-//Change related imput value and check if default
-function changeSourceTargetValues(repository) {
-    var repo_source = {};
-    var repo_target = {};
-<?php
-foreach ($repositories as $repository) {
-    echo "    repo_source['" . $repository . "'] = '" . $source_locales_list[$repository] . "'; \n";
-    echo "    repo_target['" . $repository . "'] = '" . $target_locales_list[$repository] . "'; \n";
-}
-?>
-    document.getElementById('source_locale').innerHTML = repo_source[repository];
-    changeDefaultSource('source_locale');
-    document.getElementById('target_locale').innerHTML = repo_target[repository];
-    changeDefaultSource('target_locale');
-
-<?php if ($url['path'] == '3locales'):?>
-    document.getElementById('target_locale2').innerHTML = repo_target[repository];
-    changeDefaultSource('target_locale2');
-<?php endif;?>
-
-
-    changeDefaultSource('repository');
-}
-//Change the label below the search field to reflect the value of "Search in"
-function changeSearchContext(element) {
-    document.getElementById('searchcontextvalue').innerHTML = element.options[element.selectedIndex].text;
-}
-</script>

--- a/app/views/simplesearchform.php
+++ b/app/views/simplesearchform.php
@@ -5,7 +5,7 @@
         <?php if (isset($target_locales_list)) : ?>
         <fieldset>
             <label>Locale</label>
-            <select name="locale" title="Locale">
+            <select name="locale" title="Locale" id="simplesearch_locale">
             <?=$target_locales_list?>
             </select>
         </fieldset>
@@ -14,7 +14,7 @@
         <?php if (isset($channel_selector)) : ?>
         <fieldset>
             <label>Repository</label>
-            <select name="repo" title="Repository">
+            <select name="repo" title="Repository" id="simplesearch_repository">
             <?=$channel_selector?>
             </select>
         </fieldset>

--- a/app/views/template.php
+++ b/app/views/template.php
@@ -1,7 +1,9 @@
 <?php
+namespace Transvision;
+
 ob_start();
 
-$check['repo'] = isset($check['repo']) ? $check['repo'] : 'central';
+$check['repo'] = isset($check['repo']) ? $check['repo'] : 'aurora';
 $source_locale = isset($source_locale) ? $source_locale : 'en-US';
 $locale = isset($locale) ? $locale : 'fr';
 $initial_search = isset($initial_search) ? $initial_search : 'Bookmarks';
@@ -78,6 +80,20 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     foreach ($javascript_include as $js_file) {
         echo "    <script src=\"/js/{$js_file}\"></script>\n";
     }
+
+    /* Building array of supported locales for JavaScript functions.
+     * This is inline because it shouldn't be cached by the browser.
+     * Note: encoding array_values() instead of the array makes sure
+     * that json_encode returns an array and not an object.
+     */
+    echo "<script>\n" .
+         "      var supported_locales = [];\n";
+    foreach (Project::getSupportedRepositories() as $repo_id => $repo_name) {
+        echo "      supported_locales['{$repo_id}'] = " .
+             json_encode(array_values(Project::getRepositoryLocales($repo_id))) .
+             ";\n";
+    }
+    echo "    </script>\n";
     ?>
   </head>
 <body id="<?=$page?>">

--- a/web/js/base.js
+++ b/web/js/base.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
-    // Make sure the menu is not displayed
+    // Make sure the menu is not displayed.
     $('#links-top').hide();
 
-    // Associate code to link to hide/display top menu
+    // Associate code to link to hide/display top menu.
     $('.menu-button').click(function(e) {
       e.preventDefault();
       $('#links-top').slideToggle(400, function(){
@@ -16,7 +16,7 @@ $(document).ready(function() {
       });
     });
 
-    // Associate code to toggle search options on small screens
+    // Associate code to toggle search options on small screens.
     $('.toggle-searchoptions-link').click(function(e) {
       e.preventDefault();
       $('#searchoptions').slideToggle(400, function(){
@@ -28,6 +28,28 @@ $(document).ready(function() {
       });
     });
 
-    // Focus on the search field
+    // Associate code to repository switch in simple search form.
+    $('#simplesearch_repository').on('change', function(){
+        // Store locale currently selected
+        var current_locale = $('#simplesearch_locale').val();
+
+        // Empty the select
+        $('#simplesearch_locale')
+            .find('option')
+            .remove();
+
+        // Rebuild options with locales for new repository.
+        $.each(supported_locales[this.value], function(key, locale) {
+            $('#simplesearch_locale')
+                .append($('<option>', {value : locale})
+                .text(locale));
+        });
+
+        // Try to select the same locale previously selected.
+        $('#simplesearch_locale option[value="' + current_locale + '"]')
+            .prop('selected', true);
+    });
+
+    // Focus on the main search field.
     $('#recherche').focus();
 });

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -1,0 +1,80 @@
+var check_default = function(id) {
+    /* Check if the associated 'default' checkbox needs to be selected.
+     * If the select is called 'repository', the default checkbox
+     * is called 'default_repository'.
+     */
+    var checkbox = $('#default_' + id);
+    var current_value = $('#' + id).val();
+    if (current_value === checkbox.val()) {
+        checkbox.prop('checked', true);
+    } else {
+        checkbox.prop('checked', false);
+    }
+};
+
+$(document).ready(function() {
+    // Change the label below the search field to reflect the value of "Search in".
+    $('#search_type').on('change', function(){
+        var option_label = $('#search_type option[value="' + this.value + '"]').text();
+        $('#searchcontextvalue').text(option_label);
+    });
+
+    // Associate code to repository switch in main search form.
+    $('#repository').on('change', function(){
+        var repository_id = this.value;
+        // Check if default checkbox needs to be selected.
+        check_default(this.id);
+
+        // Update all locale selectors.
+        $.each($('.mainsearch_locale_selector'), function(key, locale) {
+            // Store locale currently selected
+            var current_locale = this.value;
+
+            // Empty the select.
+            $(this).find('option').remove();
+
+            // Rebuild options with locales for new repository.
+            var locale_selector = $(this);
+            $.each(supported_locales[repository_id], function(key, locale) {
+                locale_selector.append($('<option>', {value : locale}).text(locale));
+            });
+
+            // Try to select the same locale previously selected.
+            $('#' + this.id + ' option[value="' + current_locale + '"]')
+                .prop('selected', true);
+        });
+    });
+
+    /* When a locale selector changes, checks if the default checkbox needs
+     * to be selected.
+     */
+    $('.mainsearch_locale_selector').on('change', function(){
+        check_default(this.id);
+    });
+
+    // Associate code to defaul checkbox changes to store a cookie.
+    $('.mainsearch_default_checkbox').on('change', function(){
+        var today = new Date();
+        var expire = new Date();
+        var days = 3650; // Default expire: +10 years
+        var cookie_name = this.id;
+        var cookie_value = '';
+
+        if (!$(this).prop('checked')) {
+            // If checkbox is not selected, remove cookie setting it as expired.
+            days = -1;
+        } else {
+            // The new locale must be read from the associated select
+            var select_name = this.id.replace('default_', '');
+            cookie_value = $('#' + select_name).val();
+        }
+
+        /* Set Cookie to store default value. Use checkbox ID as cookie
+         * name (e.g. default_repository) and value as content.
+         */
+        expire.setTime(today.getTime() + 3600000 * 24 * days);
+        document.cookie = cookie_name + '=' + cookie_value +
+                          ';expires=' + expire.toGMTString();
+        $(this).val(cookie_value);
+    });
+});


### PR DESCRIPTION
* Use 'aurora' as default instead of 'central' in views (previous fix was only for the main search form)
* Add back /cache folder with empty index.html
* Add JavaScript to simple search form to dinamically load the list of locales based on the selected repository
* Remove inline JavaScript from main search, removed unused functions (e.g. uncheckAll, associated to onclick event of a hidden element)

Fixes #422 