### PR TITLE
Make Transvision usable without JavaScript enabled

### DIFF
--- a/app/views/template.php
+++ b/app/views/template.php
@@ -74,32 +74,15 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     }
     ?>
     <link rel="shortcut icon" type="image/x-icon" href="http://www.mozfr.org/favicon.ico" />
-    <script src="/assets/jquery/jquery.min.js"></script>
-    <script src="/js/base.js"></script>
-    <?php
-    foreach ($javascript_include as $js_file) {
-        echo "    <script src=\"/js/{$js_file}\"></script>\n";
-    }
-
-    /* Building array of supported locales for JavaScript functions.
-     * This is inline because it shouldn't be cached by the browser.
-     * Note: encoding array_values() instead of the array makes sure
-     * that json_encode returns an array and not an object.
-     */
-    echo "<script>\n" .
-         "      var supported_locales = [];\n";
-    foreach (Project::getSupportedRepositories() as $repo_id => $repo_name) {
-        echo "      supported_locales['{$repo_id}'] = " .
-             json_encode(array_values(Project::getRepositoryLocales($repo_id))) .
-             ";\n";
-    }
-    echo "    </script>\n";
-    ?>
   </head>
 <body id="<?=$page?>">
-  <div id="links-top" class="links"><div class="container"><?=$links?></div></div>
+  <div id="links-top" class="links">
+    <div class="container">
+      <?=$links?>
+    </div>
+  </div>
   <div id="links-top-button-container">
-    <a href="" class="menu-button" id="links-top-button" title="Display Transvision Menu"><span>menu</span></a>
+    <a href="" class="menu-button" id="links-top-button" title="Hide Transvision Menu"><span>menu</span></a>
   </div>
   <?php
   if ($beta_version) {
@@ -121,11 +104,36 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     <?=$content?>
   </div>
 
+  <div id="noscript-warning">
+    Please enable JavaScript. Some features won't be available without it.
+  </div>
+
   <div id="footer">
     <p>Transvision is a tool provided by the French Mozilla community, <a href="http://www.mozfr.org" title="Home of MozFR, the French Mozilla Community" hreflang="fr">MozFR</a>.</p>
     <?php echo $last_update; ?>
   </div>
 
+  <script src="/assets/jquery/jquery.min.js"></script>
+  <script src="/js/base.js"></script>
+  <?php
+    foreach ($javascript_include as $js_file) {
+        echo "    <script src=\"/js/{$js_file}\"></script>\n";
+    }
+
+    /* Building array of supported locales for JavaScript functions.
+     * This is inline because it shouldn't be cached by the browser.
+     * Note: encoding array_values() instead of the array makes sure
+     * that json_encode returns an array and not an object.
+     */
+    echo "<script>\n" .
+         "      var supported_locales = [];\n";
+    foreach (Project::getSupportedRepositories() as $repo_id => $repo_name) {
+        echo "      supported_locales['{$repo_id}'] = " .
+             json_encode(array_values(Project::getRepositoryLocales($repo_id))) .
+             ";\n";
+    }
+    echo "    </script>\n";
+  ?>
 </body>
 </html>
 

--- a/web/js/base.js
+++ b/web/js/base.js
@@ -1,31 +1,32 @@
 $(document).ready(function() {
-    // Make sure the menu is not displayed.
-    $('#links-top').hide();
+    var hideMenuButton = function(transition) {
+        $('#links-top').slideToggle(transition, function(){
+            if ($('#links-top').is(':visible')) {
+                $('#links-top-button').attr('title', 'Hide Transvision Menu');
+                $('#links-top-button').css('background-position', '0 -38px');
+            } else {
+                $('#links-top-button').attr('title', 'Display Transvision Menu');
+                $('#links-top-button').css('background-position', '0 0');
+            }
+        });
+    };
 
     // Associate code to link to hide/display top menu.
-    $('.menu-button').click(function(e) {
+    $('#links-top-button').click(function(e) {
       e.preventDefault();
-      $('#links-top').slideToggle(400, function(){
-        if ($('#links-top').is(':visible')) {
-          $('#links-top-button').attr('title', 'Hide Transvision Menu');
-          $('#links-top-button').css('background-position', '0 -38px');
-        } else {
-          $('#links-top-button').attr('title', 'Display Transvision Menu');
-          $('#links-top-button').css('background-position', '0 0');
-        }
-      });
+      hideMenuButton(400);
     });
 
     // Associate code to toggle search options on small screens.
     $('.toggle-searchoptions-link').click(function(e) {
-      e.preventDefault();
-      $('#searchoptions').slideToggle(400, function(){
-        if ($('#searchoptions').is(':visible')) {
-          $('.toggle-searchoptions-link').text('⇑ Hide search options ⇑');
-        } else {
-          $('.toggle-searchoptions-link').text('⇓ Display search options ⇓');
-        }
-      });
+        e.preventDefault();
+        $('#searchoptions').slideToggle(400, function(){
+            if ($('#searchoptions').is(':visible')) {
+                $('.toggle-searchoptions-link').text('⇑ Hide search options ⇑');
+            } else {
+                $('.toggle-searchoptions-link').text('⇓ Display search options ⇓');
+            }
+        });
     });
 
     // Associate code to repository switch in simple search form.
@@ -49,6 +50,15 @@ $(document).ready(function() {
         $('#simplesearch_locale option[value="' + current_locale + '"]')
             .prop('selected', true);
     });
+
+    // Javascript is enabled, hide the menu without transitions
+    hideMenuButton(0);
+    $('#noscript-warning').hide();
+
+    // Hides search options on small screens (check if the warning is displayed)
+    if ($('.smallscreen_notices').is(':visible')) {
+        $('#searchoptions').hide();
+    }
 
     // Focus on the main search field.
     $('#recherche').focus();

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -188,7 +188,7 @@ h3 {
 #links-top {
     width: 100%;
     background: #fff;
-    display: none;
+    display: block;
     margin: 0;
     padding: 50px 0 20px;
     float: left;
@@ -215,13 +215,20 @@ h3 {
     margin-right: 5px;
     width: 125px;
     height: 36px;
-    background: url(/img/menu.png) top center no-repeat transparent;
+    background: url(/img/menu.png) center -38px no-repeat transparent;
 }
 
 .selected_view,
 .selected_view:visited {
     color: #00539f;
     font-weight: bold;
+}
+
+#noscript-warning {
+    color: #f2294b;
+    text-align: center;
+    font-weight: bold;
+    padding: 0 30px;
 }
 
 /* Tables */
@@ -838,15 +845,12 @@ fieldset {
         float: none;
     }
 
-    #main_search select {
+    #main_search select,
+    #main_search #search_type {
         display: inline;
     }
 
     /* Hide search options */
-    #searchoptions {
-        display: none;
-    }
-
     .smallscreen_notices {
         display: block;
         font-size: 0.8em;


### PR DESCRIPTION
Also:
* move JavaScript to the bottom of the template.
* fix ‘search type’ select at small views.