### PR TITLE
Issue #427: update the way we fetch dependencies in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     },
 
     "require": {
-        "atoum/atoum" : "dev-master",
-        "components/jquery": "1.11.*",
-        "monolog/monolog" : "1.10.0",
-        "mozillal10n/bugzilla": "0.*",
-        "mozillal10n/cache": "0.*",
-        "pascalc/tinyl10n" : "0.6",
-        "pascalc/vcs": "0.4",
-        "symfony/var-dumper": "~2.6"
+        "atoum/atoum" : "~1.1",
+        "components/jquery": "~1.1",
+        "monolog/monolog" : "~1.1",
+        "mozillal10n/bugzilla": "~0.1",
+        "mozillal10n/cache": "~0.1",
+        "pascalc/tinyl10n" : "~0.1",
+        "pascalc/vcs": "~0.1",
+        "symfony/var-dumper": "~2.1"
     },
 
     "autoload": {


### PR DESCRIPTION
- use tilde operator instead of *
- by default, check out all feature and security updates (1.x.x) but not API breaks (1.x going to 2.x)