### PR TITLE
Ignore some strings when analyzing strings for variable errors

### DIFF
--- a/app/classes/Transvision/AnalyseStrings.php
+++ b/app/classes/Transvision/AnalyseStrings.php
@@ -32,12 +32,13 @@ class AnalyseStrings
 
     /**
      * Search for strings with variables differences
-     * @param  array  $tmx_source TMX file as reference
-     * @param  array  $tmx_target TMX file for the locale to compare
-     * @param  string $repo       Name of the repo to determine the right set of regexps
+     * @param  array  $tmx_source      TMX file as reference
+     * @param  array  $tmx_target      TMX file for the locale to compare
+     * @param  string $repo            Name of the repo to determine the right set of regexps
+     * @param  array  $ignored_strings Optional list of ignored strings, default empty
      * @return array  List of entity names not matching source
      */
-    public static function differences($tmx_source, $tmx_target, $repo)
+    public static function differences($tmx_source, $tmx_target, $repo, $ignored_strings = [])
     {
         $pattern_mismatch = [];
 
@@ -49,15 +50,17 @@ class AnalyseStrings
             $patterns = [
                 'dtd'        => '/&([a-z0-9\.]+);/i',                // &foobar;
                 'printf'     => '/%([0-9]+\$){0,1}([0-9].){0,1}S/i', // %1$S or %S. %1$0.S and %0.S are valid too
-                'properties' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i',      // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
+                'properties' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i',     // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
             ];
         }
 
         foreach ($patterns as $pattern_name => $pattern) {
             foreach ($tmx_source as $key => $value) {
                 if (isset($tmx_target[$key])
-                    && $tmx_target[$key] != '') {
-                    //Check variables only if the translation exist
+                    && $tmx_target[$key] != ''
+                    && ! in_array($key, $ignored_strings)) {
+                    // Check variables only if the translation exists and
+                    // the string is not in the list of strings to ignore
                     $translation = $tmx_target[$key];
                     $wrong_variable = false;
                     preg_match_all($pattern, $value, $matches_source);

--- a/tests/units/Transvision/AnalyseStrings.php
+++ b/tests/units/Transvision/AnalyseStrings.php
@@ -34,18 +34,21 @@ class AnalyseStrings extends atoum\test
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label' => '&brandShortName; will:'],
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label' => 'Règles de conservation :'],
                 'central',
+                [],
                 ['browser/chrome/browser/preferences/privacy.dtd:historyHeader.pre.label'],
             ],
             [
                 ['apps/settings/settings.properties:bt-status-paired[one]' => '{{name}}, +{{n}} more'],
                 ['apps/settings/settings.properties:bt-status-paired[one]' => '{{name}} et un autre'],
                 'gaia',
+                [],
                 ['apps/settings/settings.properties:bt-status-paired[one]'],
             ],
             [
                 ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH' => '$BrandShortName is already running.\n\nPlease close $BrandShortName prior to launching the version you have just installed.'],
                 ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH' => 'El $BrandFullName ja s\'està executant.\n\nTanqueu el $BrandFullName abans d\'executar la versió que acabeu d\'instal·lar.'],
                 'aurora',
+                [],
                 ['browser/installer/custom.properties:WARN_MANUALLY_CLOSE_APP_LAUNCH'],
             ],
             [
@@ -54,12 +57,14 @@ class AnalyseStrings extends atoum\test
                 ['browser:foobar' => 'Le site %S demande un nom d\'utilisateur et un mot de passe.'],
                 'release',
                 [],
+                [],
             ],
             [
                 // Variable format %S, different case (not an error)
                 ['browser:foobar' => 'A username and password are being requested by %S.'],
                 ['browser:foobar' => 'Le site %s demande un nom d\'utilisateur et un mot de passe.'],
                 'release',
+                [],
                 [],
             ],
             [
@@ -68,12 +73,14 @@ class AnalyseStrings extends atoum\test
                 ['browser:foobar' => 'Le site %2$s demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$s »'],
                 'release',
                 [],
+                [],
             ],
             [
                 // Variable format %1$s, different case (not an error)
                 ['browser:foobar' => 'Invalid section name (%1$s) at line %2$s.'],
                 ['browser:foobar' => 'Nom de section (%1$S) incorrect à la ligne %1$S.'],
                 'release',
+                [],
                 [],
             ],
             [
@@ -82,12 +89,14 @@ class AnalyseStrings extends atoum\test
                 ['browser:foobar' => 'Nom de section (%S) incorrect à la ligne %S.'],
                 'release',
                 [],
+                [],
             ],
             [
                 // Using %0.S instead of %S (not an error)
                 ['browser:foobar' => 'Do you want %S to save your tabs for the next time it starts?'],
                 ['browser:foobar' => 'Salvare le schede aperte per il prossimo avvio?%0.S'],
                 'release',
+                [],
                 [],
             ],
             [
@@ -96,19 +105,30 @@ class AnalyseStrings extends atoum\test
                 ['browser:foobar' => 'Impossibile connettersi a %2$S in questo momento.%1$0.S'],
                 'release',
                 [],
+                [],
             ],
             [
                 // Mixed ordered variables %1$S and %S (error)
                 ['browser:foobar' => 'A username and password are being requested by %S. The site says: "%S"'],
                 ['browser:foobar' => 'Le site %S demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$S »'],
                 'release',
+                [],
                 ['browser:foobar'],
             ],
             [
-                // not matching test
+                // Not matching test
                 ['foobar' => 'A username and password are being requested by %2$S. The site says: "%1$S"'],
                 ['foobar' => 'Le site %2$S demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$S »'],
                 'release',
+                [],
+                [],
+            ],
+            [
+                // String should be ignored for false positives
+                ['browser:foobar' => 'A username and password are being requested by %S. The site says: "%S"'],
+                ['browser:foobar' => 'Le site %S demande un nom d\'utilisateur et un mot de passe. Le site indique : « %1$S »'],
+                'release',
+                ['browser:foobar'],
                 [],
             ],
         ];
@@ -117,11 +137,11 @@ class AnalyseStrings extends atoum\test
     /**
      * @dataProvider differencesDP
      */
-    public function testDifferences($a, $b, $c, $d)
+    public function testDifferences($a, $b, $c, $d, $e)
     {
         $obj = new _AnalyseStrings();
         $this
-            ->array($obj->differences($a, $b, $c))
-                ->isEqualTo($d);
+            ->array($obj->differences($a, $b, $c, $d))
+                ->isEqualTo($e);
     }
 }


### PR DESCRIPTION
Fix issue #444.

An alternative approach is to have exceptions directly in the class method, but it seems cleaner this way.