### PR TITLE
Check variables (l10n.js): ignore non-breaking whitespaces

### DIFF
--- a/app/classes/Transvision/AnalyseStrings.php
+++ b/app/classes/Transvision/AnalyseStrings.php
@@ -44,14 +44,14 @@ class AnalyseStrings
 
         if (Strings::startsWith($repo, 'gaia')) {
             $patterns = [
-                'l10njs'     => '/\{\{([\s]*[a-z0-9_]+[\s]*)\}\}/i', // {{foobar2}}
+                'l10njs'     => '/\{\{\s*([a-z0-9_]+)\s*\}\}/iu', // {{foobar2}}
             ];
         } else {
             $patterns = [
                 'dtd'        => '/&([a-z0-9\.]+);/i',                        // &foobar;
                 'printf'     => '/(%(?:[0-9]+\$){0,1}(?:[0-9].){0,1}(S))/i', // %1$S or %S. %1$0.S and %0.S are valid too
                 'properties' => '/(?<!%[0-9])\$[a-z0-9\.]+\b/i',             // $BrandShortName, but not "My%1$SFeeds-%2$S.opml"
-                'l10njs'     => '/\{\{([\s]*[a-z0-9_]+[\s]*)\}\}/i',         // {{foobar2}} Used in Loop and PDFViewer
+                'l10njs'     => '/\{\{\s*([a-z0-9_]+)\s*\}\}/iu',            // {{foobar2}} Used in Loop and PDFViewer
             ];
         }
 

--- a/tests/units/Transvision/AnalyseStrings.php
+++ b/tests/units/Transvision/AnalyseStrings.php
@@ -147,6 +147,14 @@ class AnalyseStrings extends atoum\test
                 [],
                 [],
             ],
+            [
+                // non-breaking space in {{ n }} (not an error)
+                ['browser:foobar15' => '{{ appName }} installed'],
+                ['browser:foobar15' => '{{ appName }} ইনস্টল রয়েছে'],
+                'gaia',
+                [],
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
\s without \u doesn’t catch non-breaking spaces
http://stackoverflow.com/questions/3230623/filter-all-types-of-whitespac
e-in-php

Also fixed the regexp to return the variable name as group.