### PR TITLE
Allow developers to toggle PERF_CHECK from config.ini

### DIFF
--- a/app/config/config.ini-dev
+++ b/app/config/config.ini-dev
@@ -26,3 +26,6 @@ libraries=/temp
 
 ; Flag to know if we are working in production more or development mode
 dev=true
+
+; Flag to display page time generation and memory usage in console logs (development mode only)
+perf_check=false

--- a/app/inc/constants.php
+++ b/app/inc/constants.php
@@ -30,5 +30,5 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
 // Special modes for the app
 define('DEBUG', (strstr(VERSION, 'dev') || isset($_GET['debug'])) ? true : false);
 
-// Set to True to log page time generation and memory used while in DEBUG mode
-const PERF_CHECK = false;
+// Set perf_check=true in config.ini to log page time generation and memory used while in DEBUG mode
+define('PERF_CHECK', isset($server_config['perf_check']) ? $server_config['perf_check'] : false);


### PR DESCRIPTION
Maybe I'm missing something, but currently to enable PERF_CHECK I edit a file tracked by Git (constants.php). And I commit this change by mistake every. single. time. :)

This PR allows us to control PERF_CHECK from an untracked file (config.ini), this way we can't commit PERF_CHECK = true.

If you prefer not to add more prefs to config.ini-dist, we could just make the change in constants.php so that we can still put the pref in our local config.ini ourselves.

Let me know what you guys think