### PR TITLE
Issue #472: API: locales service returns different structure per repo

### DIFF
--- a/app/classes/Transvision/Project.php
+++ b/app/classes/Transvision/Project.php
@@ -162,7 +162,7 @@ class Project
         if (! in_array($reference_locale, $supported_locales)) {
             $supported_locales[] = $reference_locale;
         }
-        asort($supported_locales);
+        sort($supported_locales);
 
         return $supported_locales;
     }

--- a/app/config/sources/index.php
+++ b/app/config/sources/index.php
@@ -1,2 +1,3 @@
 <?php
     # This folder needs to be writable by the user running setup.sh
+

--- a/app/views/repocomparison.php
+++ b/app/views/repocomparison.php
@@ -24,3 +24,4 @@ foreach ($locales as $locale) {
 //~ print_r($result);
 //~ echo '<pre>';
 //~ var_dump(array_diff_key($tmx_source, $tmx_target));
+


### PR DESCRIPTION
The reason is that we sure asort() which sorts arrays taking keys into account, if the source file is already sorted correctly, asort has no effect and the data returned is a simple array. If asort() changed the order of the locales, the returned array now has numeric keys. We need to use sort().