### PR TITLE
Always provide a reference datetime for Utils::ago

### DIFF
--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -389,7 +389,7 @@ class Utils extends atoum\test
 
     public function agoDP()
     {
-        return [
+        $data = [
             [
                 (new \DateTime())->modify('-2 seconds'),
                 (new \DateTime()),
@@ -397,7 +397,7 @@ class Utils extends atoum\test
             ],
             [
                 (new \DateTime())->modify('-10 hours'),
-                '',
+                (new \DateTime()),
                 '10 hours ago',
             ],
             [
@@ -407,15 +407,37 @@ class Utils extends atoum\test
             ],
             [
                 (new \DateTime())->modify('+2 months'),
-                '',
+                (new \DateTime()),
                 '2 months',
             ],
             [
                 (new \DateTime())->modify('+1 year'),
-                '',
+                (new \DateTime()),
                 '1 year',
             ],
         ];
+
+        // If running tests locally, check also the behavior without providing
+        // a reference date
+        if (! getenv('TRAVIS')) {
+            $data = array_merge(
+                $data,
+                [
+                    [
+                        (new \DateTime())->modify('-2 seconds'),
+                        '',
+                        '2 seconds ago',
+                    ],
+                    [
+                        (new \DateTime())->modify('-1 hours'),
+                        '',
+                        '1 hour ago',
+                    ],
+                ]
+            );
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
This should avoid random failures on Travis. Also add extra tests for local runs without providing a reference date.