### PR TITLE
Improve search for entities

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -162,7 +162,7 @@ class ShowResults
     {
         $replacements = [
             ' '  => '<span class="highlight-gray"> </span>',
-            '…' => '<span class="highlight-gray">…</span>',
+            '…'  => '<span class="highlight-gray">…</span>',
         ];
 
         switch ($locale) {
@@ -217,9 +217,9 @@ class ShowResults
 
             // Don't highlight search matches in entities when searching strings
             if ($search_options['search_type'] == 'strings') {
-                $result_entity = ShowResults::formatEntity($key);
+                $result_entity = Self::formatEntity($key);
             } else {
-                $result_entity = ShowResults::formatEntity($key, $recherche[0]);
+                $result_entity = Self::formatEntity($key, $recherche[0]);
             }
 
             $component = explode('/', $key)[0];
@@ -268,9 +268,9 @@ class ShowResults
             }
 
             $replacements = [
-                ' '         => '<span class="highlight-gray" title="Non breakable space"> </span>', // nbsp highlight
-                ' '        => '<span class="highlight-red" title="Thin space"> </span>', // thin space highlight
-                '…'        => '<span class="highlight-gray">…</span>', // right ellipsis highlight
+                ' '          => '<span class="highlight-gray" title="Non breakable space"> </span>', // nbsp highlight
+                ' '          => '<span class="highlight-red" title="Thin space"> </span>', // thin space highlight
+                '…'          => '<span class="highlight-gray">…</span>', // right ellipsis highlight
                 '&hellip;'   => '<span class="highlight-gray">…</span>', // right ellipsis highlight
             ];
 
@@ -402,5 +402,35 @@ class ShowResults
         $table .= "  </table>";
 
         return $table;
+    }
+
+    /**
+     * Search entity names: search full entity IDs (including path and filename),
+     * then search entity names (without the full path) if there are no results.
+     *
+     * @param array  $source_strings Array of source strings
+     * @param string $regex          Regular expression to search entity names
+     *
+     * @return array List of matching entity names
+     */
+    public static function searchEntities($source_strings, $regex)
+    {
+        // Search through the full entity ID
+        $entities = preg_grep($regex, array_keys($source_strings));
+
+        /* If there are no results, search also through the entity names.
+         * This is needed for "perfect match" when only the entity name is
+         * provided.
+         */
+        if (empty($entities)) {
+            $entity_names = [];
+            foreach ($source_strings as $entity => $translation) {
+                $entity_names[$entity] = explode(':', $entity)[1];
+            }
+            $entities = preg_grep($regex, $entity_names);
+            $entities = array_keys($entities);
+        }
+
+        return $entities;
     }
 }

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -22,7 +22,7 @@ if ($get_option('perfect_match')) {
     $regex = '~' . $whole_word . trim('^' . preg_quote($initial_search, '~') . '$') .
              $whole_word . '~' . $case_sensitive . 'u';
     if ($request->parameters[2] == 'entities') {
-        $entities = preg_grep($regex, array_keys($source_strings));
+        $entities = ShowResults::searchEntities($source_strings, $regex);
         $source_strings = array_intersect_key($source_strings, array_flip($entities));
     } else {
         $source_strings = preg_grep($regex, $source_strings);
@@ -33,7 +33,7 @@ if ($get_option('perfect_match')) {
         $regex = '~' . $whole_word . preg_quote($word, '~') .
                  $whole_word . '~' . $case_sensitive . 'u';
         if ($request->parameters[2] == 'entities') {
-            $entities = preg_grep($regex, array_keys($source_strings));
+            $entities = ShowResults::searchEntities($source_strings, $regex);
             $source_strings = array_intersect_key($source_strings, array_flip($entities));
         } else {
             $source_strings = preg_grep($regex, $source_strings);

--- a/app/models/mainsearch_entities.php
+++ b/app/models/mainsearch_entities.php
@@ -12,9 +12,9 @@ if ($url['path'] == '3locales') {
     $extra_column_header = '';
 }
 
-// Display a search hint for the closest string we have if we have no search results
-$entities = preg_grep($main_regex, array_keys($tmx_source));
+$entities = ShowResults::searchEntities($tmx_source, $main_regex);
 
+// Display a search hint for the closest string we have if we have no search results
 if (count($entities) == 0) {
     $merged_strings = [];
 

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -16,7 +16,7 @@ if ($check['perfect_match']) {
 }
 
 if ($check['search_type'] == 'strings_entities') {
-    $entities = preg_grep($main_regex, array_keys($tmx_source));
+    $entities = ShowResults::searchEntities($tmx_source, $main_regex);
     foreach ($entities as $entity) {
         $locale1_strings[$entity] = $tmx_source[$entity];
     }

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -87,7 +87,7 @@ foreach ($entities as $entity) {
       <span class='celltitle'>Entity</span>
       <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
       <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$check['repo']}' title='List all translations for this entity'>l10n</a>
-      <a class='link_to_entity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $my_search) . "</a>
+      <a class='link_to_entity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $initial_search) . "</a>
     </td>
     <td dir='{$direction1}'>
       <span class='celltitle'>{$source_locale}</span>
@@ -109,5 +109,6 @@ foreach ($entities as $entity) {
 }
 
 $table .= "</table>\n\n";
-
-print $table;
+if ($entities) {
+    print $table;
+}

--- a/tests/functional/api.php
+++ b/tests/functional/api.php
@@ -31,7 +31,7 @@ $paths = [
     ['v1/search/strings/central/en-US/fr/tralala/', 200, '[]'],
     ['v1/locales/central/', 200, '["ar","ast","cs","de","en-GB","en-US","eo","es-AR","es-CL","es-ES","es-MX","fa","fr","fy-NL","gl","he","hu","id","it","ja","ja-JP-mac","kk","ko","lt","lv","nb-NO","nl","nn-NO","pl","pt-BR","pt-PT","ru","sk","sl","sv-SE","th","tr","uk","vi","zh-CN","zh-TW"]'],
     ['v1/locales/iDontExist/', 400, '{"error":"The repo queried (iDontExist) doesn\'t exist."}'],
-    ['v1/repositories/', 200, '["release","beta","aurora","central","gaia_1_3","gaia_1_4","gaia_2_0","gaia_2_1","gaia","mozilla_org"]'],
+    ['v1/repositories/', 200, '["release","beta","aurora","central","gaia_1_3","gaia_1_4","gaia_2_0","gaia_2_1","gaia_2_2","gaia","mozilla_org"]'],
     ['v1/tm/central/en-US/fr/Bookmark/?max_results=3&min_quality=80', 200, '[{"source":"Bookmark","target":"Marquer cette page","quality":100},{"source":"Bookmark","target":"Marque-page","quality":100},{"source":"Bookmarks","target":"Marque-pages","quality":88.888888888889}]'],
     ['v1/versions/', 200, '{"v1":"stable"}'],
 ];

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -205,4 +205,64 @@ class ShowResults extends atoum\test
             ->array($obj->getRepositorySearchResults($a, $b))
                 ->isIdenticalTo($c);
     }
+
+    public function searchEntitiesDP()
+    {
+        return [
+            [
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE'  => 'test',
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE1' => 'test2',
+                ],
+                '~^browser/chrome/browser/migration/migration.properties:sourceNameIE$~i',
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE',
+                ],
+            ],
+            [
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE'  => 'test',
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE1' => 'test2',
+                ],
+                '~sourceNameIE~i',
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE',
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE1',
+                ],
+            ],
+            [
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE'  => 'test',
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE1' => 'test2',
+                ],
+                '~^sourceNameIE$~i',
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE',
+                ],
+            ],
+            [
+                [
+                    'browser/chrome/browser/migration/migration.properties:sourceNameIE' => 'test',
+                ],
+                '~foobar~',
+                [],
+            ],
+            [
+                [],
+                '~foobar~',
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider searchEntitiesDP
+     */
+    public function testSearchEntities($a, $b, $c)
+    {
+        $obj = new _ShowResults();
+        $this
+            ->array($obj->searchEntities($a, $b))
+                ->isEqualTo($c);
+    }
 }

--- a/tests/units/Transvision/Strings.php
+++ b/tests/units/Transvision/Strings.php
@@ -91,9 +91,9 @@ class Strings extends atoum\test
         return [
             [
                 [
-                    ' '         => '<span class="highlight-gray" title="Non breakable space"> </span>', // nbsp highlight
-                    ' '        => '<span class="highlight-red" title="Thin space"> </span>', // thin space highlight
-                    '…'        => '<span class="highlight-gray">…</span>', // right ellipsis highlight
+                    ' '          => '<span class="highlight-gray" title="Non breakable space"> </span>', // nbsp highlight
+                    ' '          => '<span class="highlight-red" title="Thin space"> </span>', // thin space highlight
+                    '…'          => '<span class="highlight-gray">…</span>', // right ellipsis highlight
                     '&hellip;'   => '<span class="highlight-gray">…</span>', // right ellipsis highlight
                 ],
                 '&hellip;  …',


### PR DESCRIPTION
* Search also in entity names if search on full entity fails (useful for "perfect match")
* Don't display the table header if there are no results

Impact in terms of performance is small, since we search through entity names only when the first search fails.

Fixes #497 