### PR TITLE
Improve the issue 318. Now the feature generate valid xml and it does…

### DIFF
--- a/app/classes/Transvision/TMX.php
+++ b/app/classes/Transvision/TMX.php
@@ -71,6 +71,14 @@ class TMX
             foreach ($strings[$source_lang] as $entity => $string_source) {
                 $string_target = isset($strings[$target_lang][$entity]) ? $strings[$target_lang][$entity] : '';
 
+                // It does not create the pair without translation
+                if (empty($string_target)) {
+                    continue;
+                }
+
+                $string_source = htmlentities($string_source, ENT_XML1);
+                $string_target = htmlentities($string_target, ENT_XML1);
+
                 // Divide the entity by two. The file and the key.
                 $entity_split = explode(":", $entity);
                 $content .= "\t" . '<tu>' . "\n"

--- a/tests/units/Transvision/TMX.php
+++ b/tests/units/Transvision/TMX.php
@@ -59,10 +59,12 @@ class TMX extends atoum\test
             [
                 [
                     'fr' => [
+                            'shared/date/date.properties:month'                                        => '',
                             'shared/date/date.properties:month-7-genitive'                             => 'août',
                             'shared/download/download.properties:unsupported_file_type_download_title' => 'Ouverture impossible',
                     ],
                     'en-US' => [
+                            'shared/date/date.properties:month'                                        => 'Open',
                             'shared/date/date.properties:month-7-genitive'                             => 'August',
                             'shared/download/download.properties:unsupported_file_type_download_title' => 'Unable to open',
                     ],


### PR DESCRIPTION
… not create the pair without translation