### PR TITLE
Issue 507:  Update Transvision for mozilla.org migration to Github

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -283,8 +283,8 @@ class ShowResults
             $locale2_short_code = $temp[0];
 
             if ($search_options['repo'] == 'mozilla_org') {
-                $locale1_path = VersionControl::svnPath($locale1, $search_options['repo'], $key);
-                $locale2_path = VersionControl::svnPath($locale2, $search_options['repo'], $key);
+                $locale1_path = VersionControl::gitPath($locale1, $search_options['repo'], $key);
+                $locale2_path = VersionControl::gitPath($locale2, $search_options['repo'], $key);
             } else {
                 $locale1_path = VersionControl::hgPath($locale1, $search_options['repo'], $key);
                 $locale2_path = VersionControl::hgPath($locale2, $search_options['repo'], $key);
@@ -331,7 +331,7 @@ class ShowResults
             // 3locales view
             if (isset($search_options["extra_locale"])) {
                 if ($search_options['repo'] == 'mozilla_org') {
-                    $locale3_path = VersionControl::svnPath($locale3, $search_options['repo'], $key);
+                    $locale3_path = VersionControl::gitPath($locale3, $search_options['repo'], $key);
                 } else {
                     $locale3_path = VersionControl::hgPath($locale3, $search_options['repo'], $key);
                 }

--- a/app/classes/Transvision/VersionControl.php
+++ b/app/classes/Transvision/VersionControl.php
@@ -20,7 +20,7 @@ class VersionControl
     {
         $vcs = [
             'hg'  => [],
-            'svn' => ['mozilla_org'],
+            'git' => ['mozilla_org'],
         ];
         $vcs['hg'] = array_merge(
             Project::getDesktopRepositories(),
@@ -194,19 +194,51 @@ class VersionControl
      */
     public static function svnPath($locale, $repo, $path)
     {
-        $url = 'http://viewvc.svn.mozilla.org/vc/';
-
-        // remove entity and project name from path
-        $path          = explode(':', $path);
-        $path          = $path[0];
-        $path          = explode('/', $path);
-        array_shift($path);
-        $path          = implode('/', $path);
-
         if ($repo == 'mozilla_org') {
-            $url .= 'projects/mozilla.com/trunk/locales/' . $locale . '/' . $path;
+            $file_path = 'projects/mozilla.com/trunk/locales/'
+                        . $locale . '/' . self::extractFilePath($path);
         }
 
-        return $url . '?view=markup';
+        return 'http://viewvc.svn.mozilla.org/vc/'
+               . $file_path . '?view=markup';
+    }
+
+    /**
+     * Generate a path to the GitHub repo for the file.
+     * Only mozilla.org is supported for now.
+     *
+     * @param  string $locale locale code
+     * @param  string $repo   repository name
+     * @param  string $path   Entity name representing the local file
+     * @return string Path to the file in remote GitHub repository
+     */
+    public static function gitPath($locale, $repo, $path)
+    {
+        switch ($repo) {
+            case 'mozilla_org':
+            default:
+                $repo = 'www.mozilla.org';
+                break;
+        }
+
+        return 'https://github.com/mozilla-l10n/'
+               . $repo . '/blob/master/'
+               . $locale . '/' . self::extractFilePath($path);
+    }
+
+    /**
+     * Remove entity and project name from path
+     *
+     * @param  string $path A Transvision file path
+     * @return string The same path without the entity
+     *                     and internal project name
+     */
+    private static function extractFilePath($path)
+    {
+        $path = explode(':', $path);
+        $path = explode('/', $path[0]);
+        array_shift($path);
+
+        return implode('/', $path);
     }
 }

--- a/app/config/config.ini-dist
+++ b/app/config/config.ini-dist
@@ -12,7 +12,7 @@ local_hg=/home/pascalc/transvision/data/hg
 ; to the Git checkout of Transvision, as long as scripts have access to it.
 local_git=/home/pascalc/transvision/data/git
 
-; Path to the local SVN clones. Could be externalto the SVN checkout
+; Path to the local SVN clones. Could be external to the SVN checkout
 ; of Transvision, as long as scripts have access to it.
 local_svn=/home/pascalc/transvision/data/svn
 

--- a/app/config/config.ini-travis
+++ b/app/config/config.ini-travis
@@ -22,7 +22,7 @@ local_hg=/home/travis/build/mozfr/transvision/data/hg
 ; to the Git checkout of Transvision, as long as scripts have access to it.
 local_git=/home/travis/build/mozfr/transvision/data/git
 
-; Path to the local SVN clones. Could be externalto the SVN checkout
+; Path to the local SVN clones. Could be external to the SVN checkout
 ; of Transvision, as long as scripts have access to it.
 local_svn=/home/travis/build/mozfr/transvision/data/svn
 

--- a/app/inc/constants.php
+++ b/app/inc/constants.php
@@ -4,12 +4,13 @@
 const VERSION = '3.9dev';
 
 // Constants for the project
-define('DATA_ROOT',     $server_config['root']);
-define('HG',            $server_config['local_hg'] . '/');
-define('SVN',           $server_config['local_svn'] . '/');
-define('TMX',           DATA_ROOT . '/TMX/');
-define('INSTALL_ROOT',  $server_config['install'] . '/');
-define('APP_SOURCES',   $server_config['config'] . '/sources/');
+define('DATA_ROOT',     realpath($server_config['root']) . '/');
+define('HG',            realpath($server_config['local_hg']) . '/');
+define('SVN',           realpath($server_config['local_svn']) . '/');
+define('GIT',           realpath($server_config['local_git']) . '/');
+define('TMX',           DATA_ROOT . 'TMX/');
+define('INSTALL_ROOT',  realpath($server_config['install']) . '/');
+define('APP_SOURCES',   realpath($server_config['config']) . '/sources/');
 define('WEB_ROOT',      INSTALL_ROOT . 'web/');
 define('APP_ROOT',      INSTALL_ROOT . 'app/');
 define('INC',           APP_ROOT . 'inc/');

--- a/app/scripts/bash_variables.sh
+++ b/app/scripts/bash_variables.sh
@@ -43,7 +43,7 @@ do
 done
 
 # Location of Dotlang-based repos
-mozilla_org=$local_svn/mozilla_org/
+mozilla_org=$local_git/mozilla_org/
 folders+=( $mozilla_org )
 
 # l20n test repo

--- a/app/scripts/glossaire.sh
+++ b/app/scripts/glossaire.sh
@@ -267,16 +267,16 @@ function updateGaiaRepo() {
     fi
 }
 
-function updateFromSVN() {
+function updateFromGitHub() {
     if $checkrepo
     then
         cd $mozilla_org
-        echogreen "Update subversion repositories"
-        svn up
+        echogreen "Update mozilla.org repository"
+        git pull origin master
     fi
     if $createTMX
     then
-        echogreen "Extract strings on svn"
+        echogreen "Extract strings for mozilla.org"
         cd $install
         nice -20 app/scripts/tmx_mozillaorg
     fi
@@ -297,7 +297,7 @@ do
 done
 
 # mozilla.org has its own extraction script
-updateFromSVN
+updateFromGitHub
 
 # Generate productization data
 cd $install

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -286,13 +286,13 @@ do
     initGaiaRepo ${gaia_version}
 done
 
-# Check out svn repos
-echogreen "mozilla.org repo being checked out from subversion"
+# Check out GitHub repos
+echogreen "mozilla.org repo being checked out from GitHub"
 cd $mozilla_org
-if [ ! -d $mozilla_org/.svn ]
+if [ ! -d $mozilla_org/.git ]
 then
     echogreen "Checking out mozilla.org repo"
-    svn co https://svn.mozilla.org/projects/mozilla.com/trunk/locales/ .
+    git clone https://github.com/mozilla-l10n/www.mozilla.org .
 fi
 
 # We now deal with L20n test repo as a specific case

--- a/app/scripts/tmx_mozillaorg
+++ b/app/scripts/tmx_mozillaorg
@@ -11,8 +11,8 @@ include __DIR__ . '/../inc/init.php';
 
 error_log('Mozilla.org: extraction of strings');
 
-foreach (Files::getFilenamesInFolder(SVN . 'mozilla_org/') as $locale) {
-    $path = SVN . "mozilla_org/{$locale}/";
+foreach (Files::getFilenamesInFolder(GIT . 'mozilla_org/') as $locale) {
+    $path = GIT . "mozilla_org/{$locale}/";
     $mozilla_org_files = Dotlang::getLangFilesList($path);
 
     $mozilla_org_files = array_map(
@@ -28,7 +28,7 @@ foreach (Files::getFilenamesInFolder(SVN . 'mozilla_org/') as $locale) {
     $reference_locale = (Project::getReferenceLocale('mozilla_org') == $locale);
 
     foreach ($mozilla_org_files as $file) {
-        $strings = Dotlang::getStrings(SVN . "mozilla_org/{$locale}/{$file}", $reference_locale);
+        $strings = Dotlang::getStrings(GIT . "mozilla_org/{$locale}/{$file}", $reference_locale);
         $total_strings += count($strings);
 
         foreach ($strings as $english => $translation) {

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -16,8 +16,8 @@ $table = "
 // Display results
 foreach ($entities as $entity) {
     if ($check['repo'] == 'mozilla_org') {
-        $path_locale1 = VersionControl::svnPath($source_locale, $check['repo'], $entity);
-        $path_locale2 = VersionControl::svnPath($locale, $check['repo'], $entity);
+        $path_locale1 = VersionControl::gitPath($source_locale, $check['repo'], $entity);
+        $path_locale2 = VersionControl::gitPath($locale, $check['repo'], $entity);
     } else {
         $path_locale1 = VersionControl::hgPath($source_locale, $check['repo'], $entity);
         $path_locale2 = VersionControl::hgPath($locale, $check['repo'], $entity);
@@ -41,7 +41,7 @@ foreach ($entities as $entity) {
         $target_string2 = str_replace(' ', '<span class="highlight-gray"> </span>', $target_string2);
 
         if ($check['repo'] == 'mozilla_org') {
-            $path_locale3 = VersionControl::svnPath($locale2, $check['repo'], $entity);
+            $path_locale3 = VersionControl::gitPath($locale2, $check['repo'], $entity);
         } else {
             $path_locale3 = VersionControl::hgPath($locale2, $check['repo'], $entity);
         }

--- a/tests/units/Transvision/VersionControl.php
+++ b/tests/units/Transvision/VersionControl.php
@@ -12,7 +12,7 @@ class VersionControl extends atoum\test
     {
         return [
             [
-                'mozilla_org', 'svn',
+                'mozilla_org', 'git',
             ],
             [
                 'gaia_1_4', 'hg',
@@ -136,6 +136,35 @@ class VersionControl extends atoum\test
         $obj = new _VersionControl();
         $this
             ->string($obj->svnPath($a, $b, $c))
+                ->isEqualTo($d);
+    }
+
+    public function gitFileDP()
+    {
+        return [
+            [
+                'sr',
+                'mozilla_org',
+                'mozilla_org/download_button.lang:ab34ff81',
+                'https://github.com/mozilla-l10n/www.mozilla.org/blob/master/sr/download_button.lang',
+            ],
+            [
+                'es-ES',
+                'mozilla_org',
+                'mozilla_org/firefox/os/faq.lang:c71a7a50',
+                'https://github.com/mozilla-l10n/www.mozilla.org/blob/master/es-ES/firefox/os/faq.lang',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider gitFileDP
+     */
+    public function testGitFile($a, $b, $c, $d)
+    {
+        $obj = new _VersionControl();
+        $this
+            ->string($obj->gitPath($a, $b, $c))
                 ->isEqualTo($d);
     }
 }


### PR DESCRIPTION
- setup.sh, glossaire.sh and tmx_mozillaorg now deal with github
- New VersionControl::gitPath() method generating link to file on Github
- Some refactoring with a private VersionControl::cleanFilePath() method to put code in common between svnPath() and gitpath()
- Updated tests
- in constants.php, our paths are now using realpath() + '/', this way the app doesn't break if we forget a trailing slash in config.ini

Notes:
- I am keeping svnPath() because of Firefox for iOS
- I am not adding a test for cleanFilePath() because it is a private method and it's behaviour is tested indirectly by svnPath() and gitPath()