### PR TITLE
Update results count when filtering in all views (check variables, unchanged strings)

### DIFF
--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -25,8 +25,8 @@ if ($check['search_type'] == 'strings_entities') {
 $real_search_results = count($locale1_strings);
 $limit_results = 200;
 // Limit results to 200 per locale
-array_splice($locale1_strings, $limit_results - 1);
-array_splice($locale2_strings, $limit_results - 1);
+array_splice($locale1_strings, $limit_results);
+array_splice($locale2_strings, $limit_results);
 
 $searches = [
     $source_locale => $locale1_strings,

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -5,9 +5,10 @@ namespace Transvision;
 include __DIR__ . '/simplesearchform.php';
 
 if ($error_count > 0) {
-    $content = "<h2>{$error_count} " .
-               ($error_count == 1 ? 'result' : 'results') .
-               " found</h2>\n";
+    $search_id = 'check_variable';
+    $content = "<h2><span class=\"results_count_{$search_id}\">"
+        . Utils::pluralize($error_count, 'result')
+        . "</span> found</h2>\n";
 
     if (isset($filter_block)) {
         $content .= "<div id='filters'>" .
@@ -17,7 +18,7 @@ if ($error_count > 0) {
                     "</div>\n";
     }
 
-    $content .= "<table class='collapsable'>\n" .
+    $content .= "<table class='collapsable results_table {$search_id}'>\n" .
                 "  <tr>\n" .
                 "    <th>Entity</th>\n" .
                 "    <th>{$source_locale}</th>\n" .
@@ -39,7 +40,7 @@ if ($error_count > 0) {
         $path_locale2 = VersionControl::hgPath($locale, $repo, $string_id);
 
         $component = explode('/', $string_id)[0];
-        $content .= "<tr class='{$component}'>
+        $content .= "<tr class='{$component} {$search_id}'>
                        <td>
                           <span class='celltitle'>Entity</span>
                           <a class='link_to_entity' href=\"/{$string_id_link}\">" . ShowResults::formatEntity($string_id) . "</a>

--- a/app/views/unchanged_strings.php
+++ b/app/views/unchanged_strings.php
@@ -4,7 +4,10 @@ namespace Transvision;
 // Include the common simple search form
 include __DIR__ . '/simplesearchform.php';
 
-$content = '<h2>' . count($unchanged_strings) . " strings identical to English</h2>\n";
+$search_id = 'unchanged_strings';
+$content = "<h2><span class=\"results_count_{$search_id}\">"
+    . Utils::pluralize(count($unchanged_strings), 'string')
+    . "</span> identical to English</h2>\n";
 
 if (isset($filter_block)) {
     $content .= "<div id='filters'>" .
@@ -14,7 +17,7 @@ if (isset($filter_block)) {
                 "</div>\n";
 }
 
-$content .= "<table class='collapsable'>\n";
+$content .= "<table class='collapsable results_table {$search_id}'>\n";
 $content .= "  <tr class='column_headers'>\n" .
             "    <th>String ID</th>\n" .
             "    <th>English</th>\n" .
@@ -33,7 +36,7 @@ foreach ($unchanged_strings as $string_id => $string_value) {
      */
     $direction = RTLSupport::getDirection($source_locale);
 
-    $content .= "  <tr class='{$component}'>\n" .
+    $content .= "  <tr class='{$component} {$search_id}'>\n" .
                 "    <td dir='ltr'><a href='{$entity_link}'>{$string_id}</a></td>\n" .
                 "    <td dir='{$direction}' lang='{$source_locale}'>{$string_value}</td>\n" .
                 "    <td dir='{$direction}' lang='{$locale}'>" . $strings_locale[$string_id] . "</td>\n" .

--- a/web/js/component_filter.js
+++ b/web/js/component_filter.js
@@ -24,8 +24,8 @@ $(document).ready(function() {
         available_searches.forEach(function(search_id) {
             var class_name;
             class_name = e.target.id === 'showall'
-                ? '.' + search_id
-                : '.' + search_id + '.' + e.target.id;
+                ? 'tr.' + search_id
+                : 'tr.' + search_id + '.' + e.target.id;
 
             var results_count = $(class_name).length;
             var results_message =


### PR DESCRIPTION
Also found a bug in JS that explains the 200 vs 199 results in the previous PR (counting now only table rows but also the table itself)