### PR TITLE
Stop hard-coding version information in constants.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ app/config/sources/*.txt
 cache/*.cache
 cache/lastdataupdate.txt
 cache/stats_*.json
+cache/version.txt
 composer.lock
 composer.phar
 logs/*.log

--- a/app/inc/constants.php
+++ b/app/inc/constants.php
@@ -1,8 +1,5 @@
 <?php
 
-// Bump this constant with each new release
-const VERSION = '3.10';
-
 // Constants for the project
 define('DATA_ROOT',     realpath($server_config['root']) . '/');
 define('HG',            realpath($server_config['local_hg']) . '/');
@@ -21,6 +18,14 @@ define('CACHE_ENABLED', isset($_GET['nocache']) ? false : true);
 define('CACHE_PATH',    INSTALL_ROOT . 'cache/');
 define('APP_SCHEME',    isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https://' : 'http://');
 
+if (file_exists(CACHE_PATH . 'version.txt')) {
+    define('VERSION', file_get_contents(CACHE_PATH . 'version.txt'));
+    define('BETA_VERSION', strstr(VERSION, 'dev'));
+} else {
+    define('VERSION', 'unknown.dev');
+    define('BETA_VERSION', true);
+}
+
 if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     define('CACHE_TIME',  time() - filemtime(CACHE_PATH . 'lastdataupdate.txt'));
 } else {
@@ -29,7 +34,7 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
 }
 
 // Special modes for the app
-define('DEBUG',     strstr(VERSION, 'dev') || isset($_GET['debug']));
+define('DEBUG',     BETA_VERSION || isset($_GET['debug']));
 define('LOCAL_DEV', isset($server_config['dev']) && $server_config['dev']);
 
 // Set perf_check=true in config.ini to log page time generation and memory used while in DEBUG mode

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -55,13 +55,7 @@ $links = '
 </div>
 ';
 
-if (strpos(VERSION, 'dev') !== false) {
-    $beta_version = true;
-    $title_productname = 'Transvision Beta';
-} else {
-    $beta_version = false;
-    $title_productname = 'Transvision';
-}
+$title_productname = BETA_VERSION ? 'Transvision Beta' : 'Transvision';
 
 if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     $last_update = "<p>Data last updated: " .
@@ -96,7 +90,7 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
     <a href="" class="menu-button" id="links-top-button" title="Hide Transvision Menu"><span>menu</span></a>
   </div>
   <?php
-  if ($beta_version) {
+  if (BETA_VERSION) {
       print "<div id='beta-badge'><span>BETA VERSION</span></div>\n";
   }
   ?>


### PR DESCRIPTION
* setup.sh: Move main thread code after function declarations
* setup.sh: Store version information in cache
* constants.php: Use cached information to determine BETA vs PROD version, update base.php template

The idea is to be able to update the production server without making an explicit release: simply tag the new changeset, create the release tag on GitHub and pull.