### PR TITLE
Issues #320: move all our regex logic into a unit tested class

### DIFF
--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -1,0 +1,228 @@
+<?php
+namespace Transvision;
+
+/**
+ * Search class
+ *
+ * Allows searching for data in our repositories using a fluent interface.
+ * Currently, only the regex part (definition of the search) is implemented.
+ * e.g.:
+ * $search = (new Search)
+ *     ->setSearchTerms('Bookmark this page')
+ *     ->setRegexWholeWords(true)
+ *     ->setRegexCaseInsensitive(true)
+ *     ->setRegexPerfectMatch(false);
+ */
+class Search
+{
+    /**
+     * The trimmed string searched, we keep it   as the canonical reference
+     * @var string
+     */
+    protected $search_terms;
+
+    /**
+     * The generated regex string updated dynamically via updateRegex()
+     * @var string
+     */
+    protected $regex;
+
+    /**
+     * Case sensibility of the regex
+     * @var string
+     */
+    protected $regex_case;
+
+    /**
+     * Consider the space separated string as a single word for search
+     * @var string
+     */
+    protected $regex_whole_words;
+
+    /**
+     * Only return strings that match the search perfectly (case excluded)
+     * @var boolean
+     */
+    protected $regex_perfect_match;
+
+    /**
+     * The search terms for the regex, these differ from $search_terms as
+     * they can be changed dynamically via setRegexSearchTerms()
+     * @var string
+     */
+    protected $regex_search_terms;
+
+    /**
+     * We set the default values for a search
+     */
+    public function __construct()
+    {
+        $this->search_terms = '';
+        $this->regex = '';
+        $this->regex_case = 'i';
+        $this->regex_whole_words = '';
+        $this->regex_perfect_match = false;
+        $this->regex_search_terms = '';
+    }
+
+    /**
+     * Store the searched string in $search_terms and in $regex_search_terms
+     *
+     * @param  string $string String we want to search for
+     * @return $this
+     */
+    public function setSearchTerms($string)
+    {
+        $this->search_terms = trim($string);
+        $this->regex_search_terms = $this->search_terms;
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Allows setting a new searched term for the regex.
+     * This is mostly useful when you have a multi-words search and need to
+     * loop through all the words to return results.
+     *
+     * @param  string $string The string we want to update the regex for
+     * @return $this
+     */
+    public function setRegexSearchTerms($string)
+    {
+        $this->regex_search_terms = $string;
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Set the regex case to be insensitive.
+     *
+     * @param  boolean $flag True is sensitive, false insensitive
+     * @return $this
+     */
+    public function setRegexCaseInsensitive($flag)
+    {
+        $this->regex_case = (boolean) $flag ? '' : 'i';
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Set the regex to only return perfect matches for the searched string.
+     * We cast the value to a boolean because we usually get it from a GET.
+     *
+     * @param  boolean $flag Set to True for a perfect match
+     * @return $this
+     */
+    public function setRegexPerfectMatch($flag)
+    {
+        $this->regex_perfect_match = (boolean) $flag;
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Set the regex so as that a multi-word search is taken as a single word.
+     * We cast the value to a boolean because we usually get it from a GET.
+     *
+     * @param  boolean $flag A string evaluated to True will add \b to the regex
+     * @return $this
+     */
+    public function setRegexWholeWords($flag)
+    {
+        $this->regex_whole_words = (boolean) $flag ? '\b' : '';
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Update the $regex_search_terms value every time a setter to the regex
+     * is called.
+     *
+     * @return $this
+     */
+    private function updateRegex()
+    {
+        if ($this->regex_perfect_match) {
+            $search =  '^' . $this->regex_search_terms . '$';
+        } else {
+            $search = preg_quote($this->regex_search_terms, '~');
+        }
+
+        $this->regex =
+            '~'
+            . $this->regex_whole_words
+            . $search
+            . $this->regex_whole_words
+            . '~'
+            . $this->regex_case
+            . 'u';
+
+        return $this;
+    }
+
+    /**
+     * Get the regex string
+     *
+     * @return string The regex
+     */
+    public function getRegex()
+    {
+        return $this->regex;
+    }
+
+    /**
+     * Get the state of regex_perfect_match
+     *
+     * @return boolean True if the regex searches for a perfect string match
+     */
+    public function isPerfectMatch()
+    {
+        return $this->regex_perfect_match;
+    }
+
+    /**
+     * Get search terms
+     *
+     * @return string Searched terms
+     */
+    public function getSearchTerms()
+    {
+        return $this->search_terms;
+    }
+
+    /**
+     * Get search terms in regex
+     *
+     * @return string Searched terms in regex
+     */
+    public function getRegexSearchTerms()
+    {
+        return $this->regex_search_terms;
+    }
+
+    /**
+     * Get the regex case
+     *
+     * @return string Return 'i' for case insensitive search, '' for sensitive
+     */
+    public function getRegexCase()
+    {
+        return $this->regex_case;
+    }
+
+    /**
+     * Get the regex whole words
+     *
+     * @return boolean True if we have the 'whole words' option for the regex
+     */
+    public function isWholeWords()
+    {
+        return $this->regex_whole_words;
+    }
+}

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -40,18 +40,12 @@ if (isset($_GET['search_type'])
 // Locales list for the select boxes
 $loc_list = Project::getRepositoryLocales($check['repo']);
 
-// Search for perfectMatch
-if ($check['perfect_match']) {
-    $my_search = trim('^' . $my_search . '$');
-} else {
-    $my_search = preg_quote($my_search, '/');
-}
-
-// Regex options
-$case_sensitive = $check['case_sensitive'] ? '' : 'i';
-$whole_word     = $check['whole_word']     ? '\b' : '';
-$delimiter      = '~';
-$main_regex     = $delimiter . $whole_word . $my_search . $whole_word . $delimiter . $case_sensitive;
+// Define our regex
+$search = (new Search)
+    ->setSearchTerms(Utils::cleanString($_GET['recherche']))
+    ->setRegexWholeWords($check['whole_word'])
+    ->setRegexCaseInsensitive($check['case_sensitive'])
+    ->setRegexPerfectMatch($check['perfect_match']);
 
 // build the repository switcher
 $repo_list = Utils::getHtmlSelectOptions($repos_nice_names, $check['repo'], true);

--- a/app/models/3locales_search.php
+++ b/app/models/3locales_search.php
@@ -3,14 +3,13 @@ namespace Transvision;
 
 $tmx_target2 = Utils::getRepoStrings($locale2, $check['repo']);
 
-if ($check['perfect_match']) {
-    $locale3_strings = preg_grep($regex, $tmx_target2);
+if ($search->isPerfectMatch()) {
+    $locale3_strings = preg_grep($search->getRegex(), $tmx_target2);
 } else {
     $locale3_strings = $tmx_target2;
     foreach (Utils::uniqueWords($initial_search) as $word) {
-        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-                 $whole_word . $delimiter . $case_sensitive . 'u';
-        $locale3_strings = preg_grep($regex, $locale3_strings);
+        $search->setRegexSearchTerms($word);
+        $locale3_strings = preg_grep($search->getRegex(), $locale3_strings);
     }
 }
 

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -1,6 +1,15 @@
 <?php
 namespace Transvision;
 
+// Closure to use extra parameters
+$get_option = function ($option) use ($request) {
+    if (isset($request->extra_parameters[$option])) {
+        return $request->extra_parameters[$option];
+    }
+
+    return false;
+};
+
 $repositories = ($request->parameters[2] == 'global')
     ? Project::getRepositories()
     : [$request->parameters[2]];
@@ -12,28 +21,26 @@ $target_strings_merged = [];
 $initial_search = Utils::cleanString($request->parameters[5]);
 $terms = Utils::uniqueWords($initial_search);
 
-// Regex options (not currenty used)
-$delimiter = '~';
-$whole_word = isset($check['whole_word']) ? '\b' : '';
-$case_sensitive = isset($check['case_sensitive']) ? '' : 'i';
-$regex = $delimiter . $whole_word . $initial_search . $whole_word .
-         $delimiter . $case_sensitive . 'u';
+// Define our regex
+$search = (new Search)
+    ->setSearchTerms(Utils::cleanString($initial_search))
+    ->setRegexWholeWords($get_option('whole_word'))
+    ->setRegexCaseInsensitive($get_option('case_sensitive'))
+    ->setRegexPerfectMatch($get_option('perfect_match'));
 
  // Loop through all repositories searching in both source and target languages
 foreach ($repositories as $repository) {
     $source_strings = Utils::getRepoStrings($request->parameters[3], $repository);
     foreach ($terms as $word) {
-        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-                 $whole_word . $delimiter . $case_sensitive . 'u';
-        $source_strings = preg_grep($regex, $source_strings);
+        $search->setRegexSearchTerms($word);
+        $source_strings = preg_grep($search->getRegex(), $source_strings);
     }
     $source_strings_merged = array_merge($source_strings, $source_strings_merged);
 
     $target_strings = Utils::getRepoStrings($request->parameters[4], $repository);
     foreach ($terms as $word) {
-        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-                 $whole_word . $delimiter . $case_sensitive . 'u';
-        $target_strings = preg_grep($regex, $target_strings);
+        $search->setRegexSearchTerms($word);
+        $target_strings = preg_grep($search->getRegex(), $target_strings);
     }
     $target_strings_merged = array_merge($target_strings, $target_strings_merged);
 }

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -1,6 +1,16 @@
 <?php
 namespace Transvision;
 
+// Closure to get extra parameters set
+$get_option = function ($option) use ($request) {
+    $value = 0;
+    if (isset($request->extra_parameters[$option])
+        && (int) $request->extra_parameters[$option] != 0) {
+        $value = (int) $request->extra_parameters[$option];
+    }
+
+    return $value;
+};
 $repositories = ($request->parameters[2] == 'global')
     ? Project::getRepositories()
     : [$request->parameters[2]];
@@ -12,12 +22,12 @@ $target_strings_merged = [];
 $initial_search = Utils::cleanString($request->parameters[5]);
 $terms = Utils::uniqueWords($initial_search);
 
-// Regex options (not currenty used)
-$delimiter = '~';
-$whole_word = isset($check['whole_word']) ? '\b' : '';
-$case_sensitive = isset($check['case_sensitive']) ? '' : 'i';
-$regex = $delimiter . $whole_word . $initial_search . $whole_word .
-         $delimiter . $case_sensitive . 'u';
+// Define our regex
+$search = (new Search)
+    ->setSearchTerms(Utils::cleanString($initial_search))
+    ->setRegexWholeWords($get_option('whole_word'))
+    ->setRegexCaseInsensitive($get_option('case_sensitive'))
+    ->setRegexPerfectMatch($get_option('perfect_match'));
 
 // We loop through all repositories and merge the results
 foreach ($repositories as $repository) {
@@ -25,25 +35,13 @@ foreach ($repositories as $repository) {
     $target_strings = Utils::getRepoStrings($request->parameters[4], $repository);
 
     foreach ($terms as $word) {
-        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-                 $whole_word . $delimiter . $case_sensitive . 'u';
-        $source_strings = preg_grep($regex, $source_strings);
+        $search->setRegexSearchTerms($word);
+        $source_strings = preg_grep($search->getRegex(), $source_strings);
     }
 
     $source_strings_merged = array_merge($source_strings, $source_strings_merged);
     $target_strings_merged = array_merge($target_strings, $target_strings_merged);
 }
-
-// Closure to get extra parameters set
-$get_option = function ($option) use ($request) {
-    $value = 0;
-    if (isset($request->extra_parameters[$option])
-        && (int) $request->extra_parameters[$option] != 0) {
-        $value = (int) $request->extra_parameters[$option];
-    }
-
-    return $value;
-};
 
 return $json = ShowResults::getTranslationMemoryResults(
     array_keys($source_strings_merged),

--- a/app/models/mainsearch_entities.php
+++ b/app/models/mainsearch_entities.php
@@ -12,7 +12,7 @@ if ($url['path'] == '3locales') {
     $extra_column_header = '';
 }
 
-$entities = ShowResults::searchEntities($tmx_source, $main_regex);
+$entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
 
 // Display a search hint for the closest string we have if we have no search results
 if (count($entities) == 0) {

--- a/app/models/mainsearch_glossary.php
+++ b/app/models/mainsearch_glossary.php
@@ -5,12 +5,11 @@ namespace Transvision;
 $tmx_source = Utils::getRepoStrings($source_locale, $check['repo']);
 $tmx_target = Utils::getRepoStrings($locale, $check['repo']);
 $locale1_strings = $tmx_source;
-$search = Utils::uniqueWords($initial_search);
+$search_terms = Utils::uniqueWords($initial_search);
 
-foreach ($search as $word) {
-    $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-             $whole_word . $delimiter . $case_sensitive . 'u';
-    $locale1_strings = preg_grep($regex, $locale1_strings);
+foreach ($search_terms as $word) {
+    $search->setRegexSearchTerms($word);
+    $locale1_strings = preg_grep($search->getRegex(), $locale1_strings);
 }
 
 // Limit results to 200
@@ -19,16 +18,16 @@ array_splice($locale1_strings, 200);
 $perfect = $imperfect = [];
 
 // We want to test compound words as well, /ex: 'switch to'
-$compound_search = (count($search) > 1) ? true : false;
+$compound_search = (count($search_terms) > 1) ? true : false;
 
-foreach ($search as $word) {
+foreach ($search_terms as $word) {
     // If the word is one or two letters, we skip it
     if (mb_strlen($word) < 3) {
         continue;
     }
 
     // Perfect matches are hits for a single word or a compound word
-    if ($compound_search || count($search) == 1) {
+    if ($compound_search || count($search_terms) == 1) {
         $alternate1 = ucfirst($word);
         $alternate2 = ucwords($word);
         $alternate3 = strtolower($word);

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -1,22 +1,20 @@
 <?php
 namespace Transvision;
 
-if ($check['perfect_match']) {
-    $locale1_strings = preg_grep($main_regex, $tmx_source);
-    $locale2_strings = preg_grep($main_regex, $tmx_target);
+if ($search->isPerfectMatch()) {
+    $locale1_strings = preg_grep($search->getRegex(), $tmx_source);
+    $locale2_strings = preg_grep($search->getRegex(), $tmx_target);
 } else {
     $locale1_strings = $tmx_source;
     $locale2_strings = $tmx_target;
     foreach (Utils::uniqueWords($initial_search) as $word) {
-        $regex = $delimiter . $whole_word . preg_quote($word, $delimiter) .
-                 $whole_word . $delimiter . $case_sensitive . 'u';
-        $locale1_strings = preg_grep($regex, $locale1_strings);
-        $locale2_strings = preg_grep($regex, $locale2_strings);
+        $locale1_strings = preg_grep($search->getRegex(), $locale1_strings);
+        $locale2_strings = preg_grep($search->getRegex(), $locale2_strings);
     }
 }
 
 if ($check['search_type'] == 'strings_entities') {
-    $entities = ShowResults::searchEntities($tmx_source, $main_regex);
+    $entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
     foreach ($entities as $entity) {
         $locale1_strings[$entity] = $tmx_source[$entity];
     }

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -1,0 +1,139 @@
+<?php
+namespace tests\units\Transvision;
+
+use atoum;
+use Transvision\Search as _Search;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class Search extends atoum\test
+{
+    public function testConstructor()
+    {
+        $obj = new _Search();
+        $this
+            ->string($obj->getSearchTerms())
+                ->isEqualTo('');
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('');
+        $this
+            ->string($obj->getRegexCase())
+                ->isEqualTo('i');
+        $this
+            ->string($obj->isWholeWords())
+                ->isEqualTo('');
+        $this
+            ->boolean($obj->isPerfectMatch())
+                ->isEqualTo(false);
+        $this
+            ->string($obj->getRegexSearchTerms())
+                ->isEqualTo('');
+    }
+
+    public function testSetSearchTerms()
+    {
+        $obj = new _Search();
+        $obj->setSearchTerms(' foobar ');
+        $this
+            ->string($obj->getSearchTerms())
+                ->isEqualTo('foobar');
+        $this
+            ->string($obj->getRegexSearchTerms())
+                ->isEqualTo('foobar');
+    }
+
+    public function testSetRegexSearchTerms()
+    {
+        $obj = new _Search();
+        $obj->setRegexSearchTerms('A new hope');
+        $this
+            ->string($obj->getRegexSearchTerms())
+                ->isEqualTo('A new hope')
+            ->string($obj->getRegex())
+                ->isEqualTo('~A new hope~iu');
+    }
+
+    public function testsetRegexCaseInsensitive()
+    {
+        $obj = new _Search();
+
+        // Test strings (as passed from GET)
+        $obj->setRegexCaseInsensitive('sensitive');
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~~u');
+
+        $obj->setRegexCaseInsensitive('');
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~~iu');
+
+        // Test boolean values
+        $obj->setRegexCaseInsensitive(true);
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~~u');
+
+        $obj->setRegexCaseInsensitive(false);
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~~iu');
+    }
+
+    public function testSetRegexPerfectMatch()
+    {
+        $obj = new _Search();
+        $obj->setRegexPerfectMatch('perfect_match');
+        $this
+            ->boolean($obj->isPerfectMatch())
+                ->isEqualTo(true)
+            ->string($obj->getRegex())
+                ->isEqualTo('~^$~iu');
+
+        $obj->setRegexPerfectMatch(false);
+        $this
+            ->boolean($obj->isPerfectMatch())
+                ->isEqualTo(false)
+            ->string($obj->getRegex())
+                ->isEqualTo('~~iu');
+    }
+
+    public function testSetRegexWholeWords()
+    {
+        $obj = new _Search();
+        $obj->setRegexWholeWords('whole_word');
+        $this
+            ->string($obj->isWholeWords())
+                ->isEqualTo(true)
+            ->string($obj->getRegex())
+                ->isEqualTo('~\b\b~iu');
+
+        $obj->setRegexWholeWords(false);
+        $this
+            ->string($obj->isWholeWords())
+                ->isEqualTo(false)
+            ->string($obj->getRegex())
+                ->isEqualTo('~~iu');
+    }
+
+    public function testMultipleRegexChanges()
+    {
+        $obj = new _Search();
+        $obj
+            ->setSearchTerms('A new hope')
+            ->setRegexWholeWords('whole_word')
+            ->setRegexPerfectMatch(false)
+            ->setRegexCaseInsensitive('sensitive');
+        $this->string($obj->getRegex())
+                ->isEqualTo('~\bA new hope\b~u');
+
+        $obj->setSearchTerms('Return of the jedi')
+            ->setRegexWholeWords('')
+            ->setRegexPerfectMatch(true)
+            ->setRegexCaseInsensitive('');
+        $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~^Return of the jedi$~iu');
+    }
+}


### PR DESCRIPTION
I only put in this branch the treatment of the search query.
Currently the Search class only implements methods to create the regex necesary for our various views. 

This class has unit tests, so the main benefits of this patch are that the definition of the regex in models is more intuitive (creation of an object with a fluent interface) and that it should be much harder  to regress our regex code in our models now.