### PR TITLE
Missing break line in RSS feed

### DIFF
--- a/app/views/changelog_rss.php
+++ b/app/views/changelog_rss.php
@@ -41,6 +41,8 @@ foreach ($changelog as $release => $changes) {
         $output .= isset($attributes['authors'])
                     ? $authors($attributes['authors'])
                     : '';
+
+        $output .= '<br>';
     }
     $output .= $github_link($release);
     $output .= ' ]]></description>' . "\n";


### PR DESCRIPTION
Looking at  https://transvision-beta.mozfr.org/rss/ , I shouldn’t have removed this br before we’ve merged 19111c67c256c0a4736dd9b57bcf3d9f9836f19b. For each release, all items appear on the same line in Firefox.