### PR TITLE
Issue #551: fix autocomplete in Chrome

### DIFF
--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
                         + $('#target_locale').val() + '/'
                         + query + '/';
                 },
-                params: 'max_results=10',
+                params: { max_results: 10 },
                 minChars: 2,
                 transformResult: function(response) {
                     var data = JSON.parse(response);


### PR DESCRIPTION
Chrome does not take the 'params' option into account to update the query with this error message:

Uncaught TypeError: Cannot assign to read only property 'query' of max_results=10b.getSuggestions @ jquery.autocomplete.min.js?v=unknown.dev:8b.onValueChange @ jquery.autocomplete.min.js?v=unknown.dev:8b.onKeyUp @ jquery.autocomplete.min.js?v=unknown.dev:8(anonymous function) @ jquery.autocomplete.min.js?v=unknown.dev:8m.event.dispatch @ jquery.min.js?v=unknown.dev:4r.handle @ jquery.min.js?v=unknown.dev:4

Appending the max_results paramater directly to the return value of serviceurl works in both Firefox and Chrome