### PR TITLE
Save memory on Global search API

### DIFF
--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -41,6 +41,7 @@ foreach ($repositories as $repository) {
 
     $source_strings_merged = array_merge($source_strings, $source_strings_merged);
     $target_strings_merged = array_merge($target_strings, $target_strings_merged);
+    unset($source_strings, $target_strings);
 }
 
 return $json = ShowResults::getTranslationMemoryResults(


### PR DESCRIPTION
By unsetting the $target_strings and $source_strings, we save 9MB per request, which is probably a good thing for performances of the API (for Pontoon).

That's an easy win on existing code.