### PR TITLE
Issue #595 faster Translation Memory (tm) API

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -93,16 +93,18 @@ class ShowResults
      * Return an array of search results from our Translation Memory API
      * service with a quality index based on the levenshtein distance.
      *
-     * @param  array  $entities      The entities we want to analyse
-     * @param  array  $array_strings The strings to look into [locale1 strings, locale2 strings]
-     * @param  string $search        The string to search for
-     * @param  int    $max_results   Optional, default to 200, the max number of results we return
-     * @param  int    $min_quality   Optional, default to 0, The minimal quality index to filter result
+     * @param  array  $source_strings The source reference strings with entities as keys
+     * @param  array  $target_strings The target strings to look into with entities as keys
+     * @param  string $search         The string to search for
+     * @param  int    $max_results    Optional, default to 200, the max number of results we return
+     * @param  int    $min_quality    Optional, default to 0, The minimal quality index to filter result
      * @return array  An array of strings as [source => string, target => string, quality=> Levenshtein index]
      */
-    public static function getTranslationMemoryResults($entities, $array_strings, $search, $max_results = 200, $min_quality = 0)
+    public static function getTranslationMemoryResults($source_strings, $target_strings, $search, $max_results = 200, $min_quality = 0)
     {
-        $search_results = array_values(self::getTMXResults($entities, $array_strings));
+        $search_results = array_values(
+            self::getTMXResults(array_keys($source_strings), [$source_strings, $target_strings])
+        );
         $output = [];
 
         foreach ($search_results as $set) {

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -44,7 +44,6 @@ class ShowResults extends atoum\test
         $source = $tmx;
         include TMX . 'fr/cache_fr_central.php';
         $target = $tmx;
-        $data = [$source, $target];
         $results = [
             // We use divisions so as to have real precise numbers for float comparizon
             [
@@ -74,8 +73,8 @@ class ShowResults extends atoum\test
 
         return [
             [
-                array_keys($source),
-                $data,
+                $source,
+                $target,
                 'Bookmark',
                 $results,
             ],


### PR DESCRIPTION
```
/api/v1/tm/global/en-US/fr/Cancel/
```
Before:
[Wed Jan 20 00:04:54 2016] Memory peak: 23592960 (22.5MB)
[Wed Jan 20 00:04:54 2016] Elapsed time (s): 0.3324

After:
[Wed Jan 20 04:12:04 2016] Memory peak: 8388608 (8MB)
[Wed Jan 20 04:12:04 2016] Elapsed time (s): 0.145

The gain is ~x2.2

If the search is for a string that exists only in one small repository, mozilla.org for example, the gains are even bigger (~x4):

```
/api/v1/tm/global/en-US/fr/Foundation pledge/
```
Before:
[Wed Jan 20 01:04:55 2016] Memory peak: 23330816 (22.25MB)
[Wed Jan 20 01:04:55 2016] Elapsed time (s): 0.2898

After:
Wed Jan 20 04:14:04 2016] Memory peak: 7077888 (6.75MB)
[Wed Jan 20 04:14:04 2016] Elapsed time (s): 0.0796