### PR TITLE
issue #612: Improve speed and result quality for global translation memory api

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -93,32 +93,35 @@ class ShowResults
      * Return an array of search results from our Translation Memory API
      * service with a quality index based on the levenshtein distance.
      *
-     * @param  array  $source_strings The source reference strings with entities as keys
-     * @param  array  $target_strings The target strings to look into with entities as keys
-     * @param  string $search         The string to search for
-     * @param  int    $max_results    Optional, default to 200, the max number of results we return
-     * @param  int    $min_quality    Optional, default to 0, The minimal quality index to filter result
+     * @param  array  $strings     The source and target strings to look into
+     * @param  string $search      The string to search for
+     * @param  int    $max_results Optional, default to 200, the max number of results we return
+     * @param  int    $min_quality Optional, default to 0, The minimal quality index to filter result
      * @return array  An array of strings as [source => string, target => string, quality=> Levenshtein index]
      */
-    public static function getTranslationMemoryResults($source_strings, $target_strings, $search, $max_results = 200, $min_quality = 0)
+    public static function getTranslationMemoryResults($strings, $search, $max_results = 200, $min_quality = 0)
     {
-        $search_results = array_values(
-            self::getTMXResults(array_keys($source_strings), [$source_strings, $target_strings])
-        );
-        $output = [];
+        if (empty($strings)) {
+            return [];
+        }
 
-        foreach ($search_results as $set) {
-            // We only want results for which we have a translation
-            if ($set[1]) {
-                $quality = round(Strings::levenshteinQuality($search, $set[0]), 2);
+        /*
+            Here we prepare an output array with source and target strings plus
+            a quality index.
+            $set[0] is the source string (usually English) on which we
+            calculate a quality index based on the Levenshtein algorithm.
+            $set[1] is the target string, that is the language we want
+            translations from.
+        */
+        foreach ($strings as $set) {
+            $quality = round(Strings::levenshteinQuality($search, $set[0]), 2);
 
-                if ($quality >= $min_quality) {
-                    $output[] = [
-                        'source'  => $set[0],
-                        'target'  => $set[1],
-                        'quality' => $quality,
-                    ];
-                }
+            if ($quality >= $min_quality) {
+                $output[] = [
+                    'source'  => $set[0],
+                    'target'  => $set[1],
+                    'quality' => $quality,
+                ];
             }
         }
 

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -44,6 +44,13 @@ class ShowResults extends atoum\test
         $source = $tmx;
         include TMX . 'fr/cache_fr_central.php';
         $target = $tmx;
+
+        foreach ($source as $key => $value) {
+            if (isset($target[$key])) {
+                $strings[] = [$value, $target[$key]];
+            }
+        }
+
         $results = [
             [
               'source'  => 'Bookmark',
@@ -72,8 +79,7 @@ class ShowResults extends atoum\test
 
         return [
             [
-                $source,
-                $target,
+                $strings,
                 'Bookmark',
                 $results,
             ],
@@ -83,12 +89,12 @@ class ShowResults extends atoum\test
     /**
      * @dataProvider getTranslationMemoryResultsDP
      */
-    public function testGetTranslationMemoryResults($a, $b, $c, $d)
+    public function testGetTranslationMemoryResults($a, $b, $c)
     {
         $obj = new _ShowResults();
         $this
-            ->array($obj->getTranslationMemoryResults($a, $b, $c, 4))
-                ->isEqualTo($d);
+            ->array($obj->getTranslationMemoryResults($a, $b, 4))
+                ->isEqualTo($c);
     }
 
     public function formatEntityDP()


### PR DESCRIPTION
* For a global search, don't loop through all repositories, only those a locale supports (major perf gain for small locales)
* Simplify ShowResults::getTranslationMemoryResults(), send a prepared array without entities as keys
* Ignore empty localized strings in search results (happens when the entity is in the repo but empty)

For locales that do everything, this has no perf impact, for most locales that will give a small perf boost (most locales don't do mozilla-central), for locales that have less repositories (just started and only have Aurora for example, or only translating Gaia, or not translating Firefox for iOS, the perf gain can be significant).
For Guarani for example, request times are divided by 5 on my machine compared to our current code. Same for memory use.