### PR TITLE
Clear main search bar when user click on the clear button #574 + typo

### DIFF
--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
         var option_label = $('#search_type option[value="' + this.value + '"]').text();
         $('#searchcontextvalue').text(option_label);
         check_default(this.id);
-        // Check if suggestions shoul be disabled or enabled
+        // Check if suggestions should be disabled or enabled
         check_suggestions();
     });
 
@@ -148,6 +148,7 @@ $(document).ready(function() {
     // Clear the search field when clicking on the X button
     $('#clear_search').on('click', function() {
         $('#recherche').val('').focus();
+        $('#recherche').autocomplete().clear();
         $(this).hide();
     });
 });


### PR DESCRIPTION
When search suggestions are displayed, clicking on the clear button hides the suggestions and clear the field as requested in #574 

+ small typo fix in code comment