### PR TITLE
Fix #604, adding two links for an API always working

### DIFF
--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -438,10 +438,31 @@ class Utils
      * This is used on views which also exist in our public API
      * https://github.com/mozfr/transvision/wiki/JSON-API
      *
-     * @return string URL with 'json' appended as part of the query string
+     * @param  boolean $revert if true, invert the locale and the source_locale in the API generated link
+     * @return string  URL with 'json' appended as part of the query string
      */
-    public static function redirectToAPI()
+    public static function redirectToAPI($revert = false)
     {
-        return $_SERVER["REQUEST_URI"] . (is_null($_SERVER['QUERY_STRING']) ? '?json' : '&json');
+        if (! is_null($_SERVER['QUERY_STRING'])) {
+            // Allow to revert the locale and the sourcelocale when redirecting to the API
+            if ($revert) {
+                $arg = [];
+                parse_str($_SERVER['QUERY_STRING'], $arg);
+                $sourcelocale = $arg['sourcelocale'];
+                $arg['sourcelocale'] = $arg['locale'];
+                $arg['locale'] = $sourcelocale;
+                $query = http_build_query($arg);
+            } else {
+                $query = $_SERVER['QUERY_STRING'];
+            }
+            $address = (strstr($_SERVER['REQUEST_URI'], '?') ?
+                strstr($_SERVER['REQUEST_URI'], '?', true) :
+                $_SERVER['REQUEST_URI']) . '?' .  $query;
+        } else {
+            $query = null;
+            $address = $_SERVER['REQUEST_URI'];
+        }
+
+        return $address . (is_null($query) ? '?json' : '&json');
     }
 }

--- a/app/views/templates/api_promotion.php
+++ b/app/views/templates/api_promotion.php
@@ -1,4 +1,19 @@
+<?php
+    if ($controller == 'mainsearch') {
+        ?>
+<p class="api_link">
+    <span>API</span>These results are also available as an API request for <a href="<?=\Transvision\Utils::redirectToAPI()?>"><?=$requested_sourcelocale?></a> or <a href="<?=\Transvision\Utils::redirectToAPI(true)?>"><?=$requested_locale?></a>.<br>
+    <a href="https://github.com/mozfr/transvision/wiki/JSON-API">Learn more about the Transvision API</a>.
+</p>
+<?php
+
+    } else {
+        ?>
 <p class="api_link">
     <span>API</span>These results are also available as an <a href="<?=\Transvision\Utils::redirectToAPI()?>">API request</a>.<br>
-    <a href="https://github.com/mozfr/transvision/wiki/JSON-API">Learn more about Transvision API</a>.
+    <a href="https://github.com/mozfr/transvision/wiki/JSON-API">Learn more about the Transvision API</a>.
 </p>
+<?php
+
+    }
+?>

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -458,11 +458,13 @@ class Utils extends atoum\test
     {
         return [
             [
-                'http://transvision.mozfr.org/string/?entity=browser/chrome/browser/downloads/downloads.properties:stateStarting&repo=central',
-                'http://transvision.mozfr.org/string/?entity=browser/chrome/browser/downloads/downloads.properties:stateStarting&repo=central&json',
+                'http://transvision.mozfr.org/string/?recherche=screen&repo=aurora&sourcelocale=en-US&locale=fr&search_type=strings',
+                'http://transvision.mozfr.org/string/?recherche=screen&repo=aurora&sourcelocale=en-US&locale=fr&search_type=strings&json',
+                'http://transvision.mozfr.org/string/?recherche=screen&repo=aurora&sourcelocale=fr&locale=en-US&search_type=strings&json',
             ],
             [
                 'http://transvision.mozfr.org/api/v1/versions/',
+                'http://transvision.mozfr.org/api/v1/versions/?json',
                 'http://transvision.mozfr.org/api/v1/versions/?json',
             ],
         ];
@@ -471,15 +473,19 @@ class Utils extends atoum\test
     /**
      * @dataProvider redirectToAPIDP
      */
-    public function testRedirectToAPI($a, $b)
+    public function testRedirectToAPI($a, $b, $c)
     {
         $obj = new _Utils();
-        $_SERVER["REQUEST_URI"] = $a;
+        $_SERVER['REQUEST_URI'] = $a;
         $_SERVER['QUERY_STRING'] = isset(parse_url($a)['query'])
             ? parse_url($a)['query']
             : null;
+        $_SERVER['HTTP_HOST'] = 'http://' . parse_url($a)['host'];
         $this
             ->string($obj->redirectToAPI())
                 ->isEqualTo($b);
+        $this
+            ->string($obj->redirectToAPI(true))
+                ->isEqualTo($c);
     }
 }


### PR DESCRIPTION
In the case of no result, the API result show no result, but the view show more result because of the other local. So whe add link for the two local in the API link. See #604.