### PR TITLE
Add HTTP debug header, #593

### DIFF
--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -360,6 +360,7 @@ class Utils
                            . round((microtime(true) - $_SERVER['REQUEST_TIME_FLOAT']), 4);
             error_log($memory);
             error_log($render_time);
+            header('Transvision-perf: ' . $memory . '; ' . $render_time);
         }
     }
 


### PR DESCRIPTION
As requested in #593, there is now the memory comsuption and the time elapsed in a HTTP header if perf_debug is true