### PR TITLE
Fixes #603

### DIFF
--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -276,9 +276,6 @@ class Utils
             return '';
         }
 
-        // Remove escaped characters (quotes)
-        $string = stripslashes($string);
-
         // Filter out double spaces
         $string = Strings::mtrim($string);
 

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -205,8 +205,8 @@ class Utils extends atoum\test
                 'toto',
             ],
             [
-                'don\'t escape',
-                "don't escape",
+                "don\u0027t strip unicode escaped chars",
+                "don\u0027t strip unicode escaped chars",
             ],
         ];
     }


### PR DESCRIPTION
* Removes an unneeded call to stripslashes
* Removes a test that didn't actually test anything except for the PHP parser itself
* Test that backslashes are not removed again when escaping unicode entities (even if they possibly need to be in other cases)