### PR TITLE
Refactor glossaire.sh to create TMX only when necessary

### DIFF
--- a/app/scripts/tmxmaker.py
+++ b/app/scripts/tmxmaker.py
@@ -93,14 +93,16 @@ if __name__ == "__main__":
         rcsClient = silme.io.Manager.get('file')
         try:
             l10nPackage_reference = rcsClient.get_package(path_reference, object_type='entitylist')
-        except:
+        except Exception as e:
             print 'Silme couldn\'t extract data for ' + path_reference
+            print e
             continue
 
         try:
             l10nPackage_locale = rcsClient.get_package(path_locale, object_type='entitylist')
-        except:
+        except Exception as e:
             print 'Silme couldn\'t extract data for ' + path_locale
+            print e
             continue
 
         strings = {}


### PR DESCRIPTION
I also took the chance to fix some style/coding issues:
- Don't use UPPERCASE for variable names, leave it only for system variables like `$PATH`.
- Don't check boolean variables with `if $boolean_var`, since it's [not necessarily safe](http://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script).

The final rewrite is quite heavy, but the idea is pretty simple:
- Instead of having a `createTMX` variable, we now have a `forceTMX`, which can be used to force TMX creation without pulling the repos (e.g. you manually change a string in a repository).
- When updating a locale's repository, we store information if the hg command actually pulled changesets. No point in recreating a TMX if there are no changes inside the locale.
– We always build the TMX for en-US, and check if it changes after a pull. All repositories have a lot of code changes, but that doesn't mean that there are new strings. If en-US has changed, we rebuild all locales, even if there were no changes in the l10n repository.

For mozilla.org and iOS we always create the TMX, I don't think it makes sense to complicate the code to threat them differently. I've also removed the L20n test, I don't think it makes much sense to keep it around at this point.

P.S. I tried to embed `buildCache` into `updateLocale`, but there are way too many variables to pass around to make it happen.

Fixes #634 