### PR TITLE
Issue #593: add http headers with perf metrics

### DIFF
--- a/app/controllers/api.php
+++ b/app/controllers/api.php
@@ -8,6 +8,8 @@ $request = new API($url);
 if (! $request->isValidRequest()) {
     $json = $request->invalidAPICall();
     include VIEWS . 'json.php';
+
+    return;
 }
 
 switch ($request->getService()) {

--- a/app/inc/dispatcher.php
+++ b/app/inc/dispatcher.php
@@ -115,15 +115,27 @@ if ($template) {
     $content = ob_get_contents();
     ob_end_clean();
 
+    ob_start();
     // display the page
     require_once VIEWS . 'templates/base.php';
+    $content = ob_get_contents();
+    ob_end_clean();
 } else {
+    ob_start();
     if (isset($view)) {
         include VIEWS . $view . '.php';
     } else {
         include CONTROLLERS . $controller . '.php';
     }
+    $content = ob_get_contents();
+    ob_end_clean();
 }
-
+ob_start();
+// Log script performance in the HTTP headers sent to the browser
+Utils::addPerformancesHTTPHeader();
+$perf_header = ob_get_contents();
 // Log script performance in PHP integrated developement server console
 Utils::logScriptPerformances();
+ob_end_clean();
+print $perf_header . $content;
+die;

--- a/app/views/json.php
+++ b/app/views/json.php
@@ -10,7 +10,7 @@ Utils::logScriptPerformances();
 
 // We die here because we never want to send anything more after the JSON file
 $json_data = new Json;
-die($json_data->outputContent(
+print $json_data->outputContent(
     $json,
     isset($_GET['callback']) ? $_GET['callback'] : false
-));
+);

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -1,8 +1,6 @@
 <?php
 namespace Transvision;
 
-ob_start();
-
 $check['repo']  = isset($check['repo']) ? $check['repo'] : 'aurora';
 $source_locale  = isset($source_locale) ? $source_locale : 'en-US';
 $locale         = isset($locale) ? $locale : 'fr';
@@ -64,7 +62,6 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
 } else {
     $last_update = "<p>Data last updated: not available.</p>\n";
 }
-
 ?>
 <!doctype html>
 
@@ -153,11 +150,3 @@ if (! LOCAL_DEV) {
 ?>
 </body>
 </html>
-
-<?php
-
-$content = ob_get_contents();
-
-ob_end_clean();
-
-print $content;

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -482,4 +482,16 @@ class Utils extends atoum\test
             ->string($obj->redirectToAPI())
                 ->isEqualTo($b);
     }
+
+    public function testGetScriptPerformances()
+    {
+        $obj  = new _Utils();
+        $data = $obj->getScriptPerformances();
+        $this
+            ->array($data)
+                ->size->isEqualTo(3)
+            ->integer($data[0])
+            ->float($data[1])
+            ->float($data[2]);
+    }
 }


### PR DESCRIPTION
- New header: Transvision-perf
- Does not depend on DEBUG of PERF_CHECK to be checked because we don't impact the server logs with http headers and it allows getting perf metrics on production easily