### PR TITLE
Create view to display translation inconsistencies

### DIFF
--- a/app/classes/Transvision/Consistency.php
+++ b/app/classes/Transvision/Consistency.php
@@ -1,0 +1,117 @@
+<?php
+namespace Transvision;
+
+/**
+ * Consistency class
+ *
+ * Functions used to analyze translation consistency
+ *
+ * @package Transvision
+ */
+class Consistency
+{
+    /**
+     * Find duplicated strings (strings with the same text, ignoring case).
+     *
+     * @param array $strings_array Array of strings in the form
+     *                             string_id => string_value
+     *
+     * @return array Array of duplicated strings, same format as the
+     *               input array
+     */
+    public static function findDuplicates($strings_array)
+    {
+        $duplicates = [];
+        // Use array_filter to exclude empty strings
+        $strings_array = array_filter($strings_array);
+        asort($strings_array);
+
+        $previous_key = '';
+        $previous_value = '';
+        foreach ($strings_array as $key => $value) {
+            if (strcasecmp($previous_value, $value) === 0) {
+                $duplicates[$previous_key] = $previous_value;
+                $duplicates[$key] = $value;
+            }
+            $previous_value = $value;
+            $previous_key = $key;
+        }
+
+        return $duplicates;
+    }
+
+     /**
+      * Filter out strings that should not be evaluted for consistency.
+      *
+      * @param  array $strings_array Array of strings in the form
+      *                              string_id => string_value
+      * @param  string Repository identifier
+      *
+      * @return array Array of filtered strings, with known false positives
+      *               removed
+      */
+     public static function filterStrings($strings_array, $repo)
+     {
+         if (in_array($repo, Project::getDesktopRepositories())) {
+             $repository_type = 'desktop';
+         } elseif (in_array($repo, Project::getGaiaRepositories())) {
+             $repository_type = 'gaia';
+         } else {
+             $repository_type = $repo;
+         }
+
+         // Determine if a string should be excluded
+         $ignore_string = function ($key, $value) use ($repository_type) {
+             // Ignore strings of length 1 (e.g. accesskeys) and empty strings.
+             if (strlen($value) <= 1) {
+                 return true;
+             }
+
+             // Exclude CSS rules, "width:" or "height:"
+             if (Strings::inString($value, ['width:', 'height:'])) {
+                 return true;
+             }
+
+             // Exclude CSS width values like '38em'
+             if (preg_match('/[\d|\.]+em/', $value)) {
+                 return true;
+             }
+
+             if ($repository_type == 'gaia') {
+                 // Ignore plural forms containing [] in the key
+                 if (Strings::inString($key, ['[', ']'])) {
+                     return true;
+                 }
+
+                 // Ignore accessibility strings
+                 if (strpos($key, 'accessibility.properties') !== false) {
+                     return true;
+                 }
+             }
+
+             if ($repository_type == 'desktop') {
+                 /*
+                    Ignore some specific files:
+                    - AccessFu.properties: there are accessibility
+                      strings that remain identical for English in full and
+                      abbreviated form.
+                    - defines.inc (language pack attribution)
+                    - region.properties
+                 */
+                 if (Strings::inString($key, ['AccessFu.properties', 'defines.inc', 'region.properties'])) {
+                     return true;
+                 }
+             }
+
+             return false;
+         };
+
+         foreach ($strings_array as $key => $value) {
+             if ($ignore_string($key, $value)) {
+                 unset($strings_array[$key]);
+             }
+         }
+
+         return $strings_array;
+     }
+}

--- a/app/classes/Transvision/Strings.php
+++ b/app/classes/Transvision/Strings.php
@@ -64,15 +64,29 @@ class Strings
     }
 
     /**
-     * Check if $needle is in $haystack
+     * Check if $needles are in $haystack
      *
-     * @param  string  $haystack String to analyse
-     * @param  string  $needle   The string to look for
-     * @return boolean True if the $haystack string contains $needle
+     * @param string  $haystack  String to analyze
+     * @param mixed   $needles   The string (or array of strings) to look for
+     * @param boolean $match_all True if we need to match all $needles, false
+     *                           if it's enough to match one. Default: false
+     *
+     * @return boolean True if the $haystack string contains any/all $needles
      */
-    public static function inString($haystack, $needle)
+    public static function inString($haystack, $needles, $match_all = false)
     {
-        return mb_strpos($haystack, $needle, $offset = 0, 'UTF-8') !== false ? true : false;
+        $matches = 0;
+        foreach ((array) $needles as $needle) {
+            if (mb_strpos($haystack, $needle, $offset = 0, 'UTF-8') !== false) {
+                // If I need to match any needle, I can stop at the first match
+                if (! $match_all) {
+                    return true;
+                }
+                $matches++;
+            }
+        }
+
+        return $matches == count($needles);
     }
 
     /**

--- a/app/controllers/consistency.php
+++ b/app/controllers/consistency.php
@@ -1,0 +1,8 @@
+<?php
+namespace Transvision;
+
+// Get requested repo and locale
+require_once INC . 'l10n-init.php';
+
+include MODELS . 'consistency.php';
+include VIEWS . 'consistency.php';

--- a/app/inc/dispatcher.php
+++ b/app/inc/dispatcher.php
@@ -20,38 +20,27 @@ switch ($url['path']) {
         $page_title = '3 locales search';
         $page_descr = 'One source locale, get search results for two target locales';
         break;
-    case 'news':
-        $controller = 'changelog';
-        $page_title = 'Transvision News and Release Notes';
+    case 'accesskeys':
+        $view = 'accesskeys';
+        $page_title = 'Access Keys';
+        $page_descr = 'Check your access keys.';
+        break;
+    case Strings::StartsWith($url['path'], 'api'):
+        $controller = 'api';
+        $page_title = 'API response';
         $page_descr = '';
-        $css_include = ['changelog.css'];
-        break;
-    case 'rss':
-        $controller = 'changelog';
         $template = false;
-        break;
-    case 'stats':
-        $view = 'showrepos';
-        $page_title = 'Status Overview';
-        $page_descr = 'Repository status overview.';
-        break;
-    case 'repocomparison':
-        $view = 'repocomparison';
-        break;
-    case 'gaia':
-        $view = 'gaia';
-        $page_title = 'Gaia Comparison';
-        $page_descr = 'Check the Status of your GAIA strings across repositories.';
         break;
     case 'channelcomparison':
         $controller = 'channelcomparison';
         $page_title = 'Channel Comparison';
         $page_descr = 'Compare strings from channel to channel.';
         break;
-    case 'accesskeys':
-        $view = 'accesskeys';
-        $page_title = 'Access Keys';
-        $page_descr = 'Check your access keys.';
+    case 'consistency':
+        $experimental = true;
+        $controller = 'consistency';
+        $page_title = 'Translation Consistency';
+        $page_descr = 'Analyze translation consistency across repositories.';
         break;
     case 'credits':
         $view = 'credits';
@@ -64,12 +53,41 @@ switch ($url['path']) {
         $page_descr = 'Create and download your own <abbr title="Translation Memory eXchange">TMX</abbr> file containing the strings you need.';
         $css_include = ['tmx.css'];
         break;
+    case 'gaia':
+        $view = 'gaia';
+        $page_title = 'Gaia Comparison';
+        $page_descr = 'Check the Status of your GAIA strings across repositories.';
+        break;
+    case 'news':
+        $controller = 'changelog';
+        $page_title = 'Transvision News and Release Notes';
+        $page_descr = '';
+        $css_include = ['changelog.css'];
+        break;
+    case 'productization':
+        $view = 'productization';
+        $page_title = 'Productization Overview';
+        $page_descr = 'Show productization aspects for this locale.';
+        $css_include = ['productization.css'];
+        break;
+    case 'repocomparison':
+        $view = 'repocomparison';
+        break;
+    case 'rss':
+        $controller = 'changelog';
+        $template = false;
+        break;
     case 'showrepos':
         $experimental = true;
         $controller = 'health_status';
         $page_title = 'Health status';
         $page_descr = 'Check the health status of locales.';
         $css_include = ['health.css'];
+        break;
+    case 'stats':
+        $view = 'showrepos';
+        $page_title = 'Status Overview';
+        $page_descr = 'Repository status overview.';
         break;
     case 'string':
         $controller = 'onestring';
@@ -85,18 +103,6 @@ switch ($url['path']) {
         $controller = 'check_variables';
         $page_title = 'Variables Overview';
         $page_descr = 'Show potential errors related to missing or mispelled variables in your strings.';
-        break;
-    case 'productization':
-        $view = 'productization';
-        $page_title = 'Productization Overview';
-        $page_descr = 'Show productization aspects for this locale.';
-        $css_include = ['productization.css'];
-        break;
-    case Strings::StartsWith($url['path'], 'api'):
-        $controller = 'api';
-        $page_title = 'API response';
-        $page_descr = '';
-        $template = false;
         break;
     default:
         $controller = 'mainsearch';

--- a/app/inc/urls.php
+++ b/app/inc/urls.php
@@ -6,6 +6,7 @@ $urls = [
     'rss'               => 'rss',
     'stats'             => 'stats',
     'channelcomparison' => 'channelcomp',
+    'consistency'       => 'consistency',
     'accesskeys'        => 'keys',
     'credits'           => 'credits',
     'downloads'         => 'downloads',

--- a/app/models/consistency.php
+++ b/app/models/consistency.php
@@ -1,0 +1,75 @@
+<?php
+namespace Transvision;
+
+// Build arrays for the search form, ignore mozilla.org
+$channel_selector = Utils::getHtmlSelectOptions(
+    array_diff($repos_nice_names, ['mozilla.org']),
+    $repo,
+    true
+);
+
+$target_locales_list = Utils::getHtmlSelectOptions(
+    Project::getRepositoryLocales($repo),
+    $locale
+);
+
+$reference_locale = Project::getReferenceLocale($repo);
+
+// Set a default for the number of strings to display
+$strings_number = 0;
+
+$source_strings = Utils::getRepoStrings($reference_locale, $repo);
+// Ignore empty strings in translations
+$target_strings = array_filter(Utils::getRepoStrings($locale, $repo));
+
+if (! empty($source_strings)) {
+    // Remove known problematic strings
+    $duplicated_strings_english = Consistency::filterStrings($source_strings, $repo);
+    // Find strings that are identical in English
+    $duplicated_strings_english = Consistency::findDuplicates($duplicated_strings_english);
+}
+
+if (! empty($duplicated_strings_english)) {
+    $inconsistent_translations = [];
+    $available_translations = [];
+
+    /*
+        Using CachingIterator to be able to look ahead during the foreach
+        cycle, since it's an associative array.
+        http://php.net/manual/en/class.cachingiterator.php
+    */
+    $collection = new \CachingIterator(new \ArrayIterator($duplicated_strings_english));
+    foreach ($collection as $key => $value) {
+        // Ignore this string if is not available in the localization
+        if (! isset($target_strings[$key])) {
+            $available_translations = [];
+            continue;
+        }
+
+        $available_translations[] = $target_strings[$key];
+        /*
+            If the current English string is different from the previous one,
+            or I am at the last element, I need to store it with all available
+            translations collected so far.
+
+            $collection->getInnerIterator()->current() stores the value of
+            the next element.
+        */
+        if (! $collection->hasNext() || $collection->getInnerIterator()->current() != $value) {
+            $available_translations = array_unique($available_translations);
+            /*
+                Store this string only if there's more than one translation.
+                If there's only one, translations are consistent.
+            */
+            if (count($available_translations) > 1) {
+                $inconsistent_translations[] = [
+                    'source' => $value,
+                    'target' => $available_translations,
+                ];
+            }
+            $available_translations = [];
+        }
+    }
+
+    $strings_number = count($inconsistent_translations);
+}

--- a/app/scripts/generate_sources
+++ b/app/scripts/generate_sources
@@ -59,12 +59,10 @@ if ($gaia_versions) {
 // Create a JSON file with the list of all supported repositories in the correct order
 $json_repositories = [];
 foreach ($repositories as $repository) {
-    if ($repository['type'] != 'test') {
-        $json_repositories[intval($repository['display_order'])] = [
-            'id'   => $repository['id'],
-            'name' => $repository['name']
-        ];
-    }
+    $json_repositories[intval($repository['display_order'])] = [
+        'id'   => $repository['id'],
+        'name' => $repository['name']
+    ];
 }
 ksort($json_repositories);
 echo "* Saving JSON record of all supported repositories\n";

--- a/app/views/consistency.php
+++ b/app/views/consistency.php
@@ -1,0 +1,57 @@
+<?php
+namespace Transvision;
+
+?>
+<form name="searchform" id="simplesearchform" method="get" action="">
+    <fieldset id="main_search">
+
+        <?php if (isset($target_locales_list)) : ?>
+        <fieldset>
+            <label>Locale</label>
+            <select name="locale" title="Locale" id="simplesearch_locale">
+            <?=$target_locales_list?>
+            </select>
+        </fieldset>
+        <?php endif; ?>
+
+        <?php if (isset($channel_selector)) : ?>
+        <fieldset>
+            <label>Repository</label>
+            <select name="repo" title="Repository" id="simplesearch_repository">
+            <?=$channel_selector?>
+            </select>
+        </fieldset>
+        <?php endif; ?>
+
+        <input type="hidden" name="display" value="true" />
+        <input type="submit" value="Go" alt="Go" />
+    </fieldset>
+</form>
+
+<?php
+if ($strings_number == 0) {
+    echo '<div class="message"><p>No inconsistent translations found.</p></div>';
+} else {
+    ?>
+    <table>
+        <tr>
+            <th>English String</th>
+            <th>Available Translations</th>
+        </tr>
+<?php
+    foreach ($inconsistent_translations as $data) {
+        $search_link = "/?sourcelocale={$reference_locale}"
+        . "&locale={$locale}"
+        . "&repo={$repo}"
+        . '&search_type=strings&recherche=' . urlencode($data['source']);
+        echo "<tr>\n";
+        echo '<td>';
+        echo '<a href="' . $search_link . '" title="Search for this string">' . Utils::secureText($data['source']) . "</a></td>\n";
+        echo '<td>';
+        foreach ($data['target'] as $target) {
+            echo '<div class="inconsistent_translation">' . Utils::secureText($target) . "</div>\n";
+        }
+        echo "</td>\n</tr>\n";
+    }
+    echo "</table>\n";
+}

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -39,7 +39,8 @@ $links = '
     <li><a ' . ($url['path'] == 'accesskeys' ? 'class="selected_view" ' : '') . 'href="/accesskeys/" title="Check your access keys">Access Keys</a></li>
     <li><a ' . ($url['path'] == 'channelcomparison' ? 'class="selected_view" ' : '') . 'href="/channelcomparison/" title="Compare strings from channel to channel">Channel Comparison</a></li>
     <li><a ' . ($url['path'] == 'gaia' ? 'class="selected_view" ' : '') . 'href="/gaia/" title="Compare strings across Gaia channels">Gaia Comparison</a></li>
-    <li><a ' . ($url['path'] == 'unchanged_strings' ? 'class="selected_view" ' : '') . 'href="/unchanged/" title="Display all strings identical to English">Unchanged strings</a></li>
+    <li><a ' . ($url['path'] == 'consistency' ? 'class="selected_view" ' : '') . 'href="/consistency/" title="Translation Consistency">Translation Consistency</a></li>
+    <li><a ' . ($url['path'] == 'unchanged_strings' ? 'class="selected_view" ' : '') . 'href="/unchanged/" title="Display all strings identical to English">Unchanged Strings</a></li>
     <li><a ' . ($url['path'] == 'variables' ? 'class="selected_view" ' : '') . 'href="/variables/" title="Check what variable differences there are from English">Check Variables</a></li>
   </ul>
 </div>

--- a/tests/functional/pages.php
+++ b/tests/functional/pages.php
@@ -4,6 +4,8 @@ include 'includes/init.php';
 
 $paths = [
     ['channelcomparison/', 200, 'Compare strings from channel to channel', 'Key'],
+    ['consistency/?locale=fr&repo=central&display=true', 200, 'English String', 'Available Translations'],
+    ['consistency/?locale=en-US&repo=central&display=true', 200, 'No inconsistent translations found.', 'Analyze translation consistency across repositories.'],
     ['credits/', 200, 'Transvision 1.0 was created', 'Transvision is a community project under the MozFR umbrella'],
     ['downloads/', 200, 'Select which strings', 'Generate the TMX'],
     ['gaia/', 200, 'Translation Status', 'How many strings are translated'],

--- a/tests/units/Transvision/Consistency.php
+++ b/tests/units/Transvision/Consistency.php
@@ -1,0 +1,113 @@
+<?php
+namespace tests\units\Transvision;
+
+use atoum;
+use Transvision\Consistency as _Consistency;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class Consistency extends atoum\test
+{
+    public function findDuplicates_DP()
+    {
+        return [
+            [
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'                               => 'Aller à la dernière page',
+                    'browser/pdfviewer/viewer.properties:last_page.title'                               => 'Aller à la dernière page',
+                    'browser/chrome/browser/migration/migration.properties:1_safari'                    => 'Préférences',
+                    'devtools/shared/gclicommands.properties:cookieListDesc'                            => 'Afficher les cookies',
+                    'browser/chrome/browser/browser.properties:popupWarningButtonUnix'                  => 'Préférences',
+                    'browser/chrome/browser/aboutPrivateBrowsing.dtd:aboutPrivateBrowsing.info.cookies' => 'Les cookies',
+                ],
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'              => 'Aller à la dernière page',
+                    'browser/pdfviewer/viewer.properties:last_page.title'              => 'Aller à la dernière page',
+                    'browser/chrome/browser/browser.properties:popupWarningButtonUnix' => 'Préférences',
+                    'browser/chrome/browser/migration/migration.properties:1_safari'   => 'Préférences',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider findDuplicates_DP
+     */
+    public function testFindDuplicatesID($a, $b)
+    {
+        $obj = new _Consistency();
+        $this
+            ->array($obj->findDuplicates($a))
+                ->isEqualTo($b);
+    }
+
+    public function filterStrings_DP()
+    {
+        return [
+            [
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'                               => 'Aller à la dernière page',
+                    'browser/branding/nightly/brand.dtd:trademarkInfo.part1'                            => '',
+                    'browser/chrome/browser/aboutPrivateBrowsing.dtd:aboutPrivateBrowsing.info.cookies' => 'Les cookies',
+                    'browser/chrome/browser/browser.properties:slowStartup.helpButton.accesskey'        => 'D',
+                    'browser/chrome/browser/preferences/applicationManager.dtd:appManager.style2'       => 'width: 20ch;',
+                    'browser/chrome/browser/preferences/applicationManager.dtd:appManager.style'        => 'width: 30em; min-height: 20em;',
+                    'extensions/irc/chrome/ceip.dtd:window.size'                                        => 'width: 42em;',
+                    'mail/chrome/messenger/importDialog.dtd:window.macWidth'                            => '45em',
+                    'browser/chrome/browser-region/region.properties:browser.search.order.1'            => 'Google',
+                    'browser/defines.inc:MOZ_LANGPACK_CREATOR'                                          => 'L\'équipe FrenchMozilla',
+                    'dom/chrome/accessibility/win/accessible.properties:press'                          => 'Appuyer',
+                    'shared/date/date.properties:days-until-long[many]'                                 => 'dans {{value}} jours',
+                    'dom/chrome/accessibility/AccessFu.properties:notation-phasorangle'                 => 'angle de phaseur',
+                    'apps/system/accessibility.properties:accessibility-listItemsCount[two]'            => '{{count}} éléments',
+                ],
+                'aurora',
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'                               => 'Aller à la dernière page',
+                    'browser/chrome/browser/aboutPrivateBrowsing.dtd:aboutPrivateBrowsing.info.cookies' => 'Les cookies',
+                    'shared/date/date.properties:days-until-long[many]'                                 => 'dans {{value}} jours',
+                    'dom/chrome/accessibility/win/accessible.properties:press'                          => 'Appuyer',
+                    'apps/system/accessibility.properties:accessibility-listItemsCount[two]'            => '{{count}} éléments',
+                ],
+            ],
+            [
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'                               => 'Aller à la dernière page',
+                    'browser/branding/nightly/brand.dtd:trademarkInfo.part1'                            => '',
+                    'browser/chrome/browser/aboutPrivateBrowsing.dtd:aboutPrivateBrowsing.info.cookies' => 'Les cookies',
+                    'browser/chrome/browser/browser.properties:slowStartup.helpButton.accesskey'        => 'D',
+                    'browser/chrome/browser/preferences/applicationManager.dtd:appManager.style2'       => 'width: 20ch;',
+                    'browser/chrome/browser/preferences/applicationManager.dtd:appManager.style'        => 'width: 30em; min-height: 20em;',
+                    'extensions/irc/chrome/ceip.dtd:window.size'                                        => 'width: 42em;',
+                    'mail/chrome/messenger/importDialog.dtd:window.macWidth'                            => '45em',
+                    'browser/chrome/browser-region/region.properties:browser.search.order.1'            => 'Google',
+                    'browser/defines.inc:MOZ_LANGPACK_CREATOR'                                          => 'L\'équipe FrenchMozilla',
+                    'dom/chrome/accessibility/win/accessible.properties:press'                          => 'Appuyer',
+                    'shared/date/date.properties:days-until-long[many]'                                 => 'dans {{value}} jours',
+                    'dom/chrome/accessibility/AccessFu.properties:notation-phasorangle'                 => 'angle de phaseur',
+                    'apps/system/accessibility.properties:accessibility-listItemsCount[two]'            => '{{count}} éléments',
+                ],
+                'gaia',
+                [
+                    'browser/pdfviewer/viewer.properties:last_page.label'                               => 'Aller à la dernière page',
+                    'browser/chrome/browser/aboutPrivateBrowsing.dtd:aboutPrivateBrowsing.info.cookies' => 'Les cookies',
+                    'browser/chrome/browser-region/region.properties:browser.search.order.1'            => 'Google',
+                    'browser/defines.inc:MOZ_LANGPACK_CREATOR'                                          => 'L\'équipe FrenchMozilla',
+                    'dom/chrome/accessibility/win/accessible.properties:press'                          => 'Appuyer',
+                    'dom/chrome/accessibility/AccessFu.properties:notation-phasorangle'                 => 'angle de phaseur',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider filterStrings_DP
+     */
+    public function testFilterStrings($a, $b, $c)
+    {
+        $obj = new _Consistency();
+        $this
+            ->array($obj->filterStrings($a, $b))
+                ->isEqualTo($c);
+    }
+}

--- a/tests/units/Transvision/Strings.php
+++ b/tests/units/Transvision/Strings.php
@@ -69,21 +69,26 @@ class Strings extends atoum\test
     public function inStringWithDP()
     {
         return [
-            ['La maison est blanche', 'blanche', true],
-            ['Le ciel est bleu', 'noir', false],
-            ['Le ciel est bleu', 'Le', true],
+            ['La maison est blanche', 'blanche', false, true],
+            ['La maison est blanche', 'blanche', true, true],
+            ['La maison est blanche', ['blanche', 'maison'], true, true],
+            ['La maison est blanche', ['blanche', 'maison'], false, true],
+            ['La maison est blanche', ['blanche', 'noir'], true, false],
+            ['La maison est blanche', ['blanche', 'noir'], false, true],
+            ['Le ciel est bleu', 'noir', false, false],
+            ['Le ciel est bleu', 'Le', false, true],
         ];
     }
 
     /**
      * @dataProvider inStringWithDP
      */
-    public function testInString($a, $b, $c)
+    public function testInString($a, $b, $c, $d)
     {
         $obj = new _Strings();
         $this
-            ->boolean($obj->inString($a, $b))
-                ->isEqualTo($c);
+            ->boolean($obj->inString($a, $b, $c))
+                ->isEqualTo($d);
     }
 
     public function multipleStringReplaceDP()

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -725,8 +725,21 @@ fieldset {
     top: -2px;
 }
 
-/* Gaia comparison view */
+/* Translation Consistency view */
+.inconsistent_translation {
+    margin: 0 0 10px 0;
+}
 
+#consistency table tr td:first-child {
+    color: #333;
+}
+
+#consistency .message {
+    width: 50%;
+    margin: 0 auto;
+}
+
+/* Gaia comparison view */
 .added_string {
     color: #008000;
 }


### PR DESCRIPTION
I think this should be ready for a review.

One note: I didn't use "perfect search" for the search link because it fails quite often, for example with HTML fragments coming from DTD with leading/trailing new lines.

Also added a "splash screen" to avoid burning resources (and let people wait for seconds) when randomly open the menu.

Fixes #410 