### PR TITLE
Improve table semantics using thead and tbody instead of a standard row as header

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -260,12 +260,15 @@ class ShowResults
         }
 
         $table  = "<table class='collapsable results_table {$search_id}'>
-                      <tr class='column_headers'>
-                        <th>Entity</th>
-                        <th>{$locale1}</th>
-                        <th>{$locale2}</th>
-                        {$extra_column_header}
-                      </tr>";
+                     <thead>
+                       <tr class='column_headers'>
+                         <th>Entity</th>
+                         <th>{$locale1}</th>
+                         <th>{$locale2}</th>
+                         {$extra_column_header}
+                       </tr>
+                     </thead>
+                     <tbody>\n";
 
         if (!$search_options['whole_word'] && !$search_options['perfect_match']) {
             $recherche = Utils::uniqueWords($recherche);
@@ -468,7 +471,7 @@ class ShowResults
                 </tr>";
         }
 
-        $table .= "  </table>";
+        $table .= "  </tbody>\n</table>\n";
 
         return $table;
     }

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -151,14 +151,14 @@ class Utils
         } else {
             echo '<table>';
         }
-        echo '<tr>' .
-             "<th>{$titles[0]}</th><th>{$titles[1]}</th>";
+        echo "<thead>\n  <tr class='column_headers'>\n" .
+             "    <th>{$titles[0]}</th><th>{$titles[1]}</th>\n";
 
         if ($arr2) {
-            echo "<th>{$titles[2]}</th><th>{$titles[3]}</th>";
+            echo "    <th>{$titles[2]}</th><th>{$titles[3]}</th>\n";
         }
 
-        echo '</tr>';
+        echo "  </tr>\n</thead>\n<tbody>\n";
 
         foreach ($arr as $key => $val) {
             echo '<tr>';
@@ -173,7 +173,7 @@ class Utils
             }
             echo '</tr>';
         }
-        echo '</table>';
+        echo "</tbody>\n</table>\n";
     }
 
     /**

--- a/app/models/unlocalized_words.php
+++ b/app/models/unlocalized_words.php
@@ -60,10 +60,13 @@ foreach ($strings_reference as $string_ref_id => $ref_words) {
         Remove punctuation characters from the strings then explode them into
         words.
     */
+    $ref_words = strip_tags($ref_words);
     $ref_words = explode(
         ' ',
         preg_replace('/\p{P}/u', '', $ref_words)
     );
+
+    $locale_words = strip_tags($locale_words);
     $locale_words = explode(
         ' ',
         preg_replace('/\p{P}/u', '', $locale_words)

--- a/app/views/channelcomparison.php
+++ b/app/views/channelcomparison.php
@@ -34,15 +34,17 @@ if (empty($common_strings)) {
     echo "<h3>Comparison is empty</h3>\n" .
          "<p class='subtitle'>There are no string differences for this locale between the {$repos_nice_names[$chan1]} and {$repos_nice_names[$chan2]} channels.</p>\n";
 } else {
-    echo "\n<table class='collapsable'>" .
-         "  <tr>\n" .
-         "    <th colspan='3'>Locale: {$locale}</th>\n" .
-         "  </tr>\n" .
-         "  <tr>\n" .
-         "    <th>Key</th>\n" .
-         "    <th>{$chan1}</th>\n" .
-         "    <th>{$chan2}</th>\n" .
-         "  </tr>\n";
+    echo "
+        <h2>Locale: {$locale}</h2>
+        <table class='collapsable'>
+          <thead>
+            <tr class='column_headers'>
+              <th>Key</th>
+              <th>{$chan1}</th>
+              <th>{$chan2}</th>
+            </tr>
+          </thead>
+          <tbody>\n";
 
     foreach ($common_strings as $key => $value) {
         echo   "  <tr>"
@@ -51,5 +53,5 @@ if (empty($common_strings)) {
              . "    <td><span class='celltitle'>{$chan2}</span><div class='string'>" . ShowResults::highlight($strings[$chan2][$key]) . "</div></td>\n"
              . "  </tr>\n";
     }
-    echo "</table>\n";
+    echo "</tbody>\n</table>\n";
 }

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -18,12 +18,16 @@ if ($error_count > 0) {
                     "</div>\n";
     }
 
-    $content .= "<table class='collapsable results_table {$search_id}'>\n" .
-                "  <tr>\n" .
-                "    <th>Entity</th>\n" .
-                "    <th>{$source_locale}</th>\n" .
-                "    <th>{$locale}</th>\n" .
-                "  </tr>\n";
+    $content .= "
+        <table class='collapsable results_table {$search_id}'>
+          <thead>
+            <tr class='column_headers'>
+              <th>Entity</th>
+              <th>{$source_locale}</th>
+              <th>{$locale}</th>
+            </tr>
+          </thead>
+          <tbody>\n";
 
     foreach ($var_errors as $string_id) {
         // Link to entity
@@ -62,7 +66,7 @@ if ($error_count > 0) {
                        </td>
                      </tr>\n";
     }
-    $content .= "</table>\n";
+    $content .= "</tbody>\n</table>\n";
 } else {
     $content = "<h2>Congratulations, no errors found.</h2>";
 }

--- a/app/views/consistency.php
+++ b/app/views/consistency.php
@@ -33,10 +33,13 @@ if ($strings_number == 0) {
 } else {
     ?>
     <table>
-        <tr>
+      <thead>
+        <tr class="column_headers">
             <th>English String</th>
             <th>Available Translations</th>
         </tr>
+      </thead>
+      <tbody>
 <?php
     foreach ($inconsistent_translations as $data) {
         $search_link = "/?sourcelocale={$reference_locale}"
@@ -52,5 +55,5 @@ if ($strings_number == 0) {
         }
         echo "</td>\n</tr>\n";
     }
-    echo "</table>\n";
+    echo "</tbody>\n</table>\n";
 }

--- a/app/views/gaia.php
+++ b/app/views/gaia.php
@@ -100,15 +100,15 @@ $sections = [
 // Overview of string count for the locale
 $overview = function ($section_title, $columns, $rows, $anchor) {
     // Titles
-    $html = '<table id="' . $anchor . '">'
-       . '<tr>'
-       . '<th colspan="3">' . $section_title . '</th>'
-       . '</tr>'
-       . '<tr>';
+    $html = "
+        <p class='section_title'>{$section_title}</p>
+        <table id='{$anchor}'>
+          <thead>
+            <tr class='column_headers'>";
     foreach ($columns as $key => $value) {
         $html .= '<th>' . $value . '</th>';
     }
-    $html .= '</tr>';
+    $html .= "</tr>\n</thead>\n<tbody>\n";
 
     // Rows
     foreach ($rows as $key => $row) {
@@ -118,7 +118,7 @@ $overview = function ($section_title, $columns, $rows, $anchor) {
         }
         $html .= '</tr>';
     }
-    $html .= '</table>';
+    $html .= "</tbody>\n</table>\n";
 
     return $html;
 };
@@ -174,17 +174,18 @@ $diverging = function ($diverging_sources, $strings, $anchor) use ($locale, $rep
     $nb_sources = count($diverging_sources) + 1;
     $width = 100 / $nb_sources;
 
-    $table = '<table id="' . $anchor . '" class="collapsable">'
-           . '<tr>'
-           . '<th colspan="' . $nb_sources . '">' . count($divergences) . ' diverging translations across repositories</th>'
-           . '</tr>'
-           . '<tr>';
-    $table .= "<th style=\"width:$width%\">Keys</th>";
+    $section_title = count($divergences) . ' diverging translations across repositories';
+    $table = "
+        <p class='section_title'>{$section_title}</p>
+        <table id='{$anchor}' class='collapsable'>
+          <thead>
+            <tr class='column_headers'>
+              <th style='width: {$width}%;'>Keys</th>";
     foreach ($diverging_sources as $key => $repo_name) {
-        $table .= "<th style=\"width:$width%\">" . $repos_nice_names[$repo_name] . '</th>';
+        $table .= "<th style='width: $width%;'>{$repos_nice_names[$repo_name]}</th>\n";
     }
 
-    $table .= '</tr>';
+    $table .= "</tr>\n</thead>\n<tbody>\n";
 
     foreach ($divergences as $v) {
         $table .= '<tr>'
@@ -195,7 +196,7 @@ $diverging = function ($diverging_sources, $strings, $anchor) use ($locale, $rep
         $table .= '</tr>';
     }
 
-    $table .= '</table>';
+    $table .= "</tbody>\n</table>\n";
 
     return $table;
 };
@@ -217,16 +218,21 @@ $common_keys = array_intersect_key($strings[$englishchanges[0] . '-en-US'], $str
 
 $repo_one = $repos_nice_names[$englishchanges[0]];
 $repo_two = $repos_nice_names[$englishchanges[1]];
-$table = '<table id="englishchanges" class="collapsable">'
-       . '<tr>'
-       . '<th colspan="3">Strings that have changed significantly in English between ' . $repo_one . ' and ' . $repo_two . ' but for which the entity name didn\'t change</th>'
-       . '</tr>'
-       . '<tr>'
-       . '<th>Key</th>'
-       . '<th>' . $repo_one . '</th>'
-       . '<th>' . $repo_two . '</th>'
-       . '</tr>';
 
+$section_title = "Strings that have changed significantly in English between {$repo_one} and {$repo_two} but for which the entity name didn’t change";
+$table = "
+    <p class='section_title'>{$section_title}</p>
+    <table id='englishchanges' class='collapsable'>
+      <thead>
+        <tr class='column_headers'>
+          <th>Key</th>
+          <th>{$repo_one}</th>
+          <th>{$repo_two}</th>
+        </tr>
+      </thead>
+      <tbody>\n";
+
+$changed_strings = 0;
 foreach ($common_keys as $key => $val) {
     $get_localized_string = function ($id) use ($key, $strings) {
         // Avoid warnings if the string is not localized
@@ -246,9 +252,14 @@ foreach ($common_keys as $key => $val) {
             . ShowResults::highlight(Utils::secureText($strings[$englishchanges[1] . '-en-US'][$key]))
             . '<br><small>' . $get_localized_string($englishchanges[1]) . '</small></div></td>'
             . '</tr>';
+        $changed_strings++;
     }
 }
-$table .= '</table>';
+
+if ($changed_strings == 0) {
+    $table .= "<tr><td colspan='3' class='no_highligth'>There are no changed strings.</td></tr>\n";
+}
+$table .= "</tbody>\n</table>\n";
 
 print $anchor_title('changed_english');
 print $table;
@@ -263,14 +274,17 @@ $strings_added = function ($reverted_comparison, $strings, $repo_one, $repo_two,
         $comparison_type = '<span class="deleted_string">' . $count . ' deleted strings</span>';
     }
 
-    $table = '<table id="' . $anchor . '" class="' . $cssclass . '">'
-           . '<tr>'
-           . '<th colspan="3">' . $comparison_type . ' between ' . $repos_nice_names[$repo_one] . ' and ' . $repos_nice_names[$repo_two] . '</th>'
-           . '</tr>'
-           . '<tr>'
-           . '<th>Key</th>'
-           . '<th>New strings</th>'
-           . '</tr>';
+    $section_title = "{$comparison_type} between {$repos_nice_names[$repo_one]} and {$repos_nice_names[$repo_two]}";
+    $table = "
+        <p class='section_title'>{$section_title}</p>
+        <table id='{$anchor}' class='{$cssclass}'>
+          <thead>
+            <tr class='column_headers'>
+              <th>Key</th>
+              <th>New strings</th>
+            </tr>
+          </thead>
+          <tbody>\n";
 
     foreach ($temp as $k => $v) {
         $translation = array_key_exists($k, $strings[$repo_one])
@@ -286,7 +300,7 @@ $strings_added = function ($reverted_comparison, $strings, $repo_one, $repo_two,
                 . '</tr>';
     }
 
-    $table .= '</table>';
+    $table .= "</tbody>\n</table>\n";
 
     return $table;
 };

--- a/app/views/gaia.php
+++ b/app/views/gaia.php
@@ -98,10 +98,10 @@ $sections = [
 <?php
 
 // Overview of string count for the locale
-$overview = function ($section_title, $columns, $rows, $anchor) {
+$overview = function ($section_description, $columns, $rows, $anchor) {
     // Titles
     $html = "
-        <p class='section_title'>{$section_title}</p>
+        <p class='section_description'>{$section_description}</p>
         <table id='{$anchor}'>
           <thead>
             <tr class='column_headers'>";
@@ -174,9 +174,9 @@ $diverging = function ($diverging_sources, $strings, $anchor) use ($locale, $rep
     $nb_sources = count($diverging_sources) + 1;
     $width = 100 / $nb_sources;
 
-    $section_title = count($divergences) . ' diverging translations across repositories';
+    $section_description = count($divergences) . ' diverging translations across repositories';
     $table = "
-        <p class='section_title'>{$section_title}</p>
+        <p class='section_description'>{$section_description}</p>
         <table id='{$anchor}' class='collapsable'>
           <thead>
             <tr class='column_headers'>
@@ -219,9 +219,9 @@ $common_keys = array_intersect_key($strings[$englishchanges[0] . '-en-US'], $str
 $repo_one = $repos_nice_names[$englishchanges[0]];
 $repo_two = $repos_nice_names[$englishchanges[1]];
 
-$section_title = "Strings that have changed significantly in English between {$repo_one} and {$repo_two} but for which the entity name didn’t change";
+$section_description = "Strings that have changed significantly in English between {$repo_one} and {$repo_two} but for which the entity name didn’t change";
 $table = "
-    <p class='section_title'>{$section_title}</p>
+    <p class='section_description'>{$section_description}</p>
     <table id='englishchanges' class='collapsable'>
       <thead>
         <tr class='column_headers'>
@@ -274,9 +274,9 @@ $strings_added = function ($reverted_comparison, $strings, $repo_one, $repo_two,
         $comparison_type = '<span class="deleted_string">' . $count . ' deleted strings</span>';
     }
 
-    $section_title = "{$comparison_type} between {$repos_nice_names[$repo_one]} and {$repos_nice_names[$repo_two]}";
+    $section_description = "{$comparison_type} between {$repos_nice_names[$repo_one]} and {$repos_nice_names[$repo_two]}";
     $table = "
-        <p class='section_title'>{$section_title}</p>
+        <p class='section_description'>{$section_description}</p>
         <table id='{$anchor}' class='{$cssclass}'>
           <thead>
             <tr class='column_headers'>

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -6,12 +6,15 @@ include VIEWS . 'templates/api_promotion.php';
 
 $table = "
 <table class='collapsable'>
-  <tr>
-    <th>Entity</th>
-    <th>{$source_locale}</th>
-    <th>{$locale}</th>
-    {$extra_column_header}
-  </tr>";
+  <thead>
+    <tr class='column_headers'>
+      <th>Entity</th>
+      <th>{$source_locale}</th>
+      <th>{$locale}</th>
+      {$extra_column_header}
+    </tr>
+  </thead>
+  <tbody>\n";
 
 $current_repo = $check['repo'];
 // Display results
@@ -109,7 +112,7 @@ foreach ($entities as $entity) {
   </tr>\n";
 }
 
-$table .= "</table>\n\n";
+$table .= "</tbody>\n</table>\n\n";
 if ($entities) {
     print $table;
 }

--- a/app/views/results_glossary.php
+++ b/app/views/results_glossary.php
@@ -14,10 +14,13 @@ if (count($perfect_results) > 0) {
 
     echo "<h2>Results</h2>
     <table class='collapsable'>
-      <tr>
-        <th>Localized string</th>
-        <th>Source string</th>
-      </tr>\n";
+      <thead>
+        <tr class='column_headers'>
+          <th>Localized string</th>
+          <th>Source string</th>
+        </tr>
+      </thead>
+      <tbody>\n";
 
     foreach ($imperfect_results as $string_id => $string_value) {
         $entity_link = "/?sourcelocale={$source_locale}"
@@ -30,7 +33,7 @@ if (count($perfect_results) > 0) {
         echo "  <td dir='{$source_locale_dir}'><span class='celltitle'>Source string</span><div class='string'>" . Utils::secureText($tmx_source[$string_id]) . "</div></td>\n";
         echo "</tr>\n";
     }
-    echo "</table>\n";
+    echo "</tbody>\n</table>\n";
 } else {
     echo "  <p>No perfect match found.</p>\n</div>\n";
 }

--- a/app/views/showrepos.php
+++ b/app/views/showrepos.php
@@ -43,17 +43,19 @@ foreach ($gaia_locales as $val) {
 
 $json = [];
 $table = '
-<style>td {text-align:right;} form[name="searchform"] { text-align: center; }</style>
-<table>
-<tr>
-    <th>Locale</th>
-    <th>Total</th>
-    <th>Missing</th>
-    <th>Translated</th>
-    <th>Identical</th>
-    <th>Completion</th>
-    <th>Status estimate</th>
-</tr>';
+<table id="showrepos_table">
+  <thead>
+    <tr class="column_headers">
+        <th>Locale</th>
+        <th>Total</th>
+        <th>Missing</th>
+        <th>Translated</th>
+        <th>Identical</th>
+        <th>Completion</th>
+        <th>Status estimate</th>
+    </tr>
+  </thead>
+  <tbody>';
 
 foreach ($string_count as $locale => $numbers) {
     $completion = $count_reference - $numbers['identical'] - $numbers['missing'];
@@ -102,7 +104,7 @@ foreach ($string_count as $locale => $numbers) {
     </tr>";
 }
 
-$table .= '</table>';
+$table .= "</tbody>\n</table>\n";
 
 if (isset($_GET['json'])) {
     include VIEWS . 'json.php';

--- a/app/views/unchanged_strings.php
+++ b/app/views/unchanged_strings.php
@@ -17,12 +17,15 @@ if (isset($filter_block)) {
                 "</div>\n";
 }
 
-$content .= "<table class='collapsable results_table {$search_id}'>\n";
-$content .= "  <tr class='column_headers'>\n" .
-            "    <th>String ID</th>\n" .
-            "    <th>English</th>\n" .
-            "    <th>Translation</th>\n" .
-            "  </tr>\n";
+$content .= "<table class='collapsable results_table {$search_id}'>
+               <thead>
+                 <tr class='column_headers'>
+                   <th>String ID</th>
+                   <th>English</th>
+                   <th>Translation</th>
+                 </tr>
+               </thead>
+               <tbody>\n";
 foreach ($unchanged_strings as $string_id => $string_value) {
     $component = explode('/', $string_id)[0];
 
@@ -43,6 +46,6 @@ foreach ($unchanged_strings as $string_id => $string_value) {
                 "    <td dir='{$direction}' lang='{$locale}'>" . $strings_locale[$string_id] . "</td>\n" .
                 "  </tr>\n";
 }
-$content .= "</table>\n";
+$content .= "</tbody>\n</table>\n";
 
 echo $content;

--- a/app/views/unlocalized_words.php
+++ b/app/views/unlocalized_words.php
@@ -6,25 +6,28 @@ include __DIR__ . '/simplesearchform.php';
 
 $search_id = 'unlocalized_strings';
 
-$content = "<table class='collapsable results_table sortable {$search_id}'>\n" .
-            "  <tr class='column_headers'>\n" .
-            "    <th>English</th>\n" .
-            "    <th>Occurrences</th>\n" .
-            "  </tr>\n";
+$content = "<table class='collapsable results_table sortable {$search_id}'>
+               <thead>
+                 <tr class='column_headers'>
+                   <th>English</th>
+                   <th>Occurrences</th>
+                 </tr>
+               </thead>
+               <tbody>\n";
 
-foreach ($unlocalized_words as $string_id => $string_value) {
-    $link = "/?recherche={$string_id}&repo={$repo}&sourcelocale={$locale}" .
+foreach ($unlocalized_words as $english_term => $string_count) {
+    $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
             "&locale={$ref_locale}&search_type=strings&whole_word=whole_word";
 
-    $link_title = $string_value == 1
+    $link_title = $string_count == 1
         ? 'Search for this occurrence'
         : 'Search for these occurrences';
 
     $content .= "  <tr class='{$search_id}'>\n" .
-                "    <td><a href='{$link}' title='{$link_title}'>{$string_id}</a></td>\n" .
-                "    <td>{$string_value}</td>\n" .
+                "    <td><a href='{$link}' title='{$link_title}'>{$english_term}</a></td>\n" .
+                "    <td>{$string_count}</td>\n" .
                 "  </tr>\n";
 }
-$content .= "</table>\n";
+$content .= "</tbody>\n</table>\n";
 
 echo $content;

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -755,7 +755,11 @@ fieldset {
     color: #008000;
 }
 
-.section_title {
+#gaia table {
+    min-width: 300px;
+}
+
+.section_description {
     text-align: center;
     font-weight: bold;
 }

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -276,15 +276,14 @@ table {
 }
 
 tr:nth-child(odd) {
-    background-color: rgba(255, 255, 255, 0.6);
-}
-
-tr:nth-child(even) {
     background-color: rgba(255, 255, 255, 0.9);
 }
 
-tr:first-child,
-#channelcomp tr:nth-child(2) {
+tr:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.6);
+}
+
+tr.column_headers {
     background-color: transparent;
     box-shadow: none;
 }
@@ -388,6 +387,10 @@ td .result_meta_link .bug_link {
 
 table tr td:first-child {
     color: #3c8fd1;
+}
+
+table tr td.no_highligth {
+    color: #333;
 }
 
 .red {
@@ -742,10 +745,6 @@ fieldset {
     margin: 0 0 10px 0;
 }
 
-#consistency table tr td:first-child {
-    color: #333;
-}
-
 #consistency .message {
     width: 50%;
     margin: 0 auto;
@@ -754,6 +753,11 @@ fieldset {
 /* Gaia comparison view */
 .added_string {
     color: #008000;
+}
+
+.section_title {
+    text-align: center;
+    font-weight: bold;
 }
 
 .deleted_string {
@@ -789,6 +793,12 @@ fieldset {
 
 #onestring tr:target {
     background-color: #90ee90;
+}
+
+/* Showrepos (/stats) */
+
+#showrepos_table td {
+    text-align: right;
 }
 
 /* Responsive */


### PR DESCRIPTION
Strip tags in unlocalized view, that also improves results (e.g. for words like "tag", "file", etc.).
Also fixes #670 