### PR TITLE
Use two columns for QA views

### DIFF
--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -31,18 +31,20 @@ $links = '
     <li><a ' . ($url['path'] == 'downloads' ? 'class="selected_view" ' : '') . 'href="/downloads/" title="Download TMX files">TMX Download</a></li>
   </ul>
 </div>
-<div class="linkscolumn">
+<div class="linkscolumn" id="qa_column">
   <h3>QA Views</h3>
   <ul>
-    <li><a ' . ($url['path'] == 'showrepos' ? 'class="selected_view" ' : '') . 'href="/showrepos/" title="Check the health status of locales">Health Status Overview</a></li>
-    <li><a ' . ($url['path'] == 'productization' ? 'class="selected_view" ' : '') . 'href="/productization/" title="Show productization aspects">Productization</a></li>
     <li><a ' . ($url['path'] == 'accesskeys' ? 'class="selected_view" ' : '') . 'href="/accesskeys/" title="Check your access keys">Access Keys</a></li>
-    <li><a ' . ($url['path'] == 'channelcomparison' ? 'class="selected_view" ' : '') . 'href="/channelcomparison/" title="Compare strings from channel to channel">Channel Comparison</a></li>
-    <li><a ' . ($url['path'] == 'gaia' ? 'class="selected_view" ' : '') . 'href="/gaia/" title="Compare strings across Gaia channels">Gaia Comparison</a></li>
+    <li><a ' . ($url['path'] == 'variables' ? 'class="selected_view" ' : '') . 'href="/variables/" title="Check what variable differences there are from English">Check Variables</a></li>
     <li><a ' . ($url['path'] == 'consistency' ? 'class="selected_view" ' : '') . 'href="/consistency/" title="Translation Consistency">Translation Consistency</a></li>
     <li><a ' . ($url['path'] == 'unchanged_strings' ? 'class="selected_view" ' : '') . 'href="/unchanged/" title="Display all strings identical to English">Unchanged Strings</a></li>
     <li><a ' . ($url['path'] == 'unlocalized_words' ? 'class="selected_view" ' : '') . 'href="/unlocalized/" title="Display common words remaining in English">Unlocalized Words</a></li>
-    <li><a ' . ($url['path'] == 'variables' ? 'class="selected_view" ' : '') . 'href="/variables/" title="Check what variable differences there are from English">Check Variables</a></li>
+  </ul>
+  <ul>
+    <li><a ' . ($url['path'] == 'channelcomparison' ? 'class="selected_view" ' : '') . 'href="/channelcomparison/" title="Compare strings from channel to channel">Channel Comparison</a></li>
+    <li><a ' . ($url['path'] == 'gaia' ? 'class="selected_view" ' : '') . 'href="/gaia/" title="Compare strings across Gaia channels">Gaia Comparison</a></li>
+    <li><a ' . ($url['path'] == 'showrepos' ? 'class="selected_view" ' : '') . 'href="/showrepos/" title="Check the health status of locales">Health Status Overview</a></li>
+    <li><a ' . ($url['path'] == 'productization' ? 'class="selected_view" ' : '') . 'href="/productization/" title="Show productization aspects">Productization</a></li>
   </ul>
 </div>
 <div class="linkscolumn">

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -187,32 +187,46 @@ h3 {
     font-size: 1em;
     margin: 4em auto 1em auto;
     text-align: left;
-    width: 550px;
+    width: 660px;
 }
 
 .links h3 {
     padding: 0 0 6px 12px;
     margin: 0;
     font-size: 14px;
-    text-align: left;
+    text-align: center;
+    width: 100%;
 }
 
 .links ul {
+    float: left;
     list-style-type: none;
-    margin: 0;
-    padding: 0 0 0 12px;
+    margin: 0 0 0 8px;
+    padding: 0;
+    width: 150px;
 }
 
 .linkscolumn {
-    width: 180px;
+    width: 140px;
     float: left;
+    padding-bottom: 10px;
+}
+
+#qa_column {
+    width: 350px;
+    border-left: 1px dotted #d9d9d9;
+    border-right: 1px dotted #d9d9d9;
+}
+
+#qa_column ul {
+    width: 165px;
 }
 
 #links-top {
     width: 100%;
     background: #fff;
     margin: 0;
-    padding: 50px 0 20px;
+    padding: 50px 0 10px;
     float: left;
     display: none;
 }
@@ -222,7 +236,7 @@ h3 {
 }
 
 #links-top .container {
-    width: 550px;
+    width: 660px;
     margin: 0 auto;
 }
 
@@ -877,18 +891,32 @@ fieldset {
     }
 
     .links {
-        font-size: 0.9em;
+        font-size: 1em;
         margin: 2em auto 1em auto;
         text-align: left;
-        width: 460px;
+        width: 100%;
     }
 
     #links-top .container {
-        width: 460px;
+        width: 100%;
     }
 
     .linkscolumn {
-        width: 150px;
+        display: block;
+        float: none;
+        width: 100%;
+        text-align: center;
+    }
+
+    #qa_column {
+        border: 0;
+        display: block;
+        width: 100%;
+    }
+
+    .links ul {
+        float: none;
+        margin: 0 auto;
     }
 
     /* special results */


### PR DESCRIPTION
Fix #663, it should be good for a test run.

Tested with Chrome and Firefox, it seems to work without particular issue. I decided to go vertical on the smaller viewport though, I think the text would be too small with 2 columns.