### PR TITLE
Issue  #680: improve security of our GitHub Web hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cache/version.txt
 composer.lock
 composer.phar
 logs/*.log
+logs/github_log.txt
 phpDocumentor.phar
 vendor
 web/assets

--- a/web/github_hook.php
+++ b/web/github_hook.php
@@ -21,7 +21,7 @@ function logHookResult($message, $success = false)
             $log_headers .= "$header: $value \n";
         }
     }
-    file_put_contents(__DIR__ . '/github_log.txt', $log_headers);
+    file_put_contents(__DIR__ . '/../logs/github_log.txt', $log_headers);
 }
 
 // CHECK: Download composer in the app root if it is not already there
@@ -38,8 +38,7 @@ if (isset($_SERVER[$header])) {
         file_get_contents("php://input"),
         $secret
     );
-
-    if ($validation == explode('=', $_SERVER[$header])[1]) {
+    if (hash_equals($validation, explode('=', $_SERVER[$header])[1])) {
         // Pull latest changes
         exec("git checkout $branch ; git pull origin $branch");
 


### PR DESCRIPTION
- use hash_equals() instead of ==
- store the log file in our logs folder, outside of the web root