### PR TITLE
Improve logic and layout in channel comparison view

### DIFF
--- a/app/models/channelcomparison.php
+++ b/app/models/channelcomparison.php
@@ -35,22 +35,27 @@ foreach ($loc_list as $loc) {
     $target_locales_list .= "\t<option" . $ch . " value=" . $loc . ">" . $loc . "</option>\n";
 }
 
+/*
+    Get locale strings available in both channels with array_intersect_key.
+    The translation stored is the one available in channel 1. Then remove
+    strings that are identical in both channels using array_diff.
+*/
 $common_strings = array_intersect_key($strings[$chan1], $strings[$chan2]);
 $common_strings = array_diff($common_strings, $strings[$chan2]);
 
-$new_strings = array_diff($strings[$chan1], $strings[$chan2]);
-$new_strings = array_diff($new_strings, $common_strings);
-
-// Get en-US locale strings
-$en_US_strings = [];
-$en_US_strings[$chan1] = Utils::getRepoStrings('en-US', $chan1);
-$en_US_strings[$chan2] = Utils::getRepoStrings('en-US', $chan2);
-
-$common_en_US_strings = array_intersect_key($en_US_strings[$chan1], $en_US_strings[$chan2]);
-$common_en_US_strings = array_diff($common_en_US_strings, $en_US_strings[$chan2]);
-
-$new_en_US_strings = array_diff($en_US_strings[$chan1], $en_US_strings[$chan2]);
-$new_en_US_strings = array_diff($new_en_US_strings, $common_en_US_strings);
-
-// Unset variable that we don't use anymore
-unset($en_US_strings, $common_en_US_strings);
+/*
+    Find new locale strings added between repositories, store them with the
+    reference string.
+*/
+$added_strings = array_diff_key($strings[$chan1], $strings[$chan2]);
+$new_strings = [];
+$en_US_strings_chan1 = Utils::getRepoStrings('en-US', $chan1);
+foreach ($added_strings as $string_id => $translation) {
+    $reference_string = isset($en_US_strings_chan1[$string_id])
+        ? $en_US_strings_chan1[$string_id]
+        : '@N/A@';
+    $new_strings[$string_id] = [
+        'reference'   => $reference_string,
+        'translation' => $translation,
+    ];
+}

--- a/app/views/channelcomparison.php
+++ b/app/views/channelcomparison.php
@@ -1,6 +1,12 @@
 <?php
 namespace Transvision;
 
+// Helper anonymous variable to output a formatted table cell
+$td = function ($key, $value) {
+    return "<td><span class=\"celltitle\">{$key}</span>"
+           . "<div class=²\"string\">{$value}</div></td>";
+};
+
 ?>
 <form id ="searchform" name="searchform" method="get" action="">
     <fieldset id="main_search">
@@ -33,10 +39,10 @@ namespace Transvision;
 <?php else: ?>
 <table class='collapsable'>
     <thead>
-        <tr>
+        <tr class='column_headers'>
             <th colspan='3'>Locale: <?=$locale?></th>
         </tr>
-        <tr>
+        <tr class='column_headers'>
             <th>Key</th>
             <th><?=$chan1?></th>
             <th><?=$chan2?></th>
@@ -45,9 +51,9 @@ namespace Transvision;
     <tbody>
     <?php foreach ($common_strings as $key => $value) : ?>
     <tr>
-        <td><span class='celltitle'>Key</span><div class='string'><?=ShowResults::formatEntity($key)?></div></td>
-        <td><span class='celltitle'><?=$chan1?></span><div class='string'><?=Utils::secureText($value)?></div></td>
-        <td><span class='celltitle'><?=$chan2?></span><div class='string'><?=Utils::secureText($strings[$chan2][$key])?></div></td>
+        <?=$td('Key', ShowResults::formatEntity($key))?>
+        <?=$td($chan1, Utils::secureText($value))?>
+        <?=$td($chan2, Utils::secureText($strings[$chan2][$key]))?>
     </tr>
     <?php endforeach; ?>
     </tbody>
@@ -58,25 +64,25 @@ namespace Transvision;
 <h3 id="new_strings">No new strings have been added</h3>
 
 <?php else : ?>
-<h3 id="new_strings">New added strings in <?=$locale?> between <?=$repos_nice_names[$chan1]?> and <?=$repos_nice_names[$chan2]?></h3>
+<h3 id="new_strings">New strings added in <em><?=$locale?></em> between <?=$repos_nice_names[$chan1]?> and <?=$repos_nice_names[$chan2]?></h3>
 <table class="collapsable">
     <thead>
-        <tr>
-            <th>Key</th>
-            <th>Value</th>
-            <th>en-US value</th>
+        <tr class='column_headers'>
+            <th>Entity</th>
+            <th>en-US</th>
+            <th><?=$locale?></th>
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($new_strings as $key => $value): ?>
+    <?php foreach ($new_strings as $string_id => $string_values): ?>
     <tr>
-        <td><span class="celltitle">Key</span><div class="string"><?=showResults::formatEntity($key)?></div></td>
-        <td><span class="celltitle">Value</span><div class="string"><?=Utils::secureText($value)?></div></td>
-        <?php if (isset($new_en_US_strings[$key])): ?>
-        <td><span class="celltitle">en-US Value</span><div class="string"><?=Utils::secureText($new_en_US_strings[$key])?></div></td>
+        <?=$td('Entity', ShowResults::formatEntity($string_id))?>
+        <?php if ($new_strings[$string_id]['reference'] != '@N/A@'): ?>
+        <?=$td('en-US', Utils::secureText($string_values['reference']))?>
         <?php else: ?>
-        <td><span class='celltitle'>en-US value</span><div class="string">(not available)</div></td>
+        <?=$td('en-US', '<em class="error">(not available)</em>')?>
         <?php endif; ?>
+        <?=$td($locale, Utils::secureText($string_values['translation']))?>
     </tr>
     <?php endforeach; ?>
     <tbody>


### PR DESCRIPTION
Simplify the logic and use the same layout of other pages: Entity, en-US, locale.