### PR TITLE
Fix current view highlight

### DIFF
--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -29,14 +29,12 @@ if (isset($css_include)) {
 $li_link = function ($page, $title, $text) use ($url, $urls) {
     $link = array_search($page, $urls);
 
+    $css_class = $url['path'] == $link ? 'class="selected_view" ' : '';
     if ($link != '/') {
         $link = "/{$link}/";
     }
 
-    return '<li><a ' . ($url['path'] == $link ? 'class="selected_view" ' : '')
-           . 'href="' . $link . '" '
-           . 'title="' . $title . '">'
-           . $text . '</a></li>';
+    return "<li><a {$css_class} href=\"{$link}\" title=\"{$title}\">{$text}</a></li>";
 };
 
 /*


### PR DESCRIPTION
Bad suggestion during code review: $link is used to determine the active view.

Also switch to a single string instead of multiple concatenations, since we’ve the lost the ternary operator (I find it more readable).