### PR TITLE
Issue #706: Set search type in the Search object

### DIFF
--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -5,18 +5,22 @@ namespace Transvision;
  * Search class
  *
  * Allows searching for data in our repositories using a fluent interface.
- * Currently, only the regex part (definition of the search) is implemented.
+ * Currently, only the regex part (definition of the search) and defining the
+ * search options are implemented.
  * e.g.:
  * $search = (new Search)
  *     ->setSearchTerms('Bookmark this page')
  *     ->setRegexWholeWords(true)
  *     ->setRegexCaseInsensitive(true)
- *     ->setRegexPerfectMatch(false);
+ *     ->setRegexPerfectMatch(false)
+ *     ->setRepository('release')
+ *     ->setSearchType('strings')
+ *     ->setLocales(['en-US', 'fr']);
  */
 class Search
 {
     /**
-     * The trimmed string searched, we keep it   as the canonical reference
+     * The trimmed string searched, we keep it as the canonical reference
      * @var string
      */
     protected $search_terms;
@@ -59,6 +63,38 @@ class Search
     protected $repository;
 
     /**
+     * The type of search we will perform
+     * @var string
+     */
+    protected $search_type;
+
+    /**
+     * The different types of search we can perform
+     * @var array
+     */
+    protected $search_types = ['strings', 'entities', 'strings_entities'];
+
+    /**
+     * The different options associated to searches
+     * @var array
+     */
+    protected $form_search_options = [
+        'case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'whole_word',
+    ];
+
+    /**
+     * The different checkboxes for the search Form
+     * @var array
+     */
+    protected $form_checkboxes;
+
+    /**
+     * The different locales we will use in views
+     * @var array
+     */
+    protected $locales;
+
+    /**
      * We set the default values for a search
      */
     public function __construct()
@@ -70,6 +106,13 @@ class Search
         $this->regex_perfect_match = false;
         $this->regex_search_terms = '';
         $this->repository = 'aurora'; // Most locales work on Aurora
+        $this->search_type = 'strings';
+        $this->locales = [];
+        $this->form_checkboxes = array_diff(
+            $this->form_search_options,
+            ['repo', 'search_type']
+        );
+        $this->form_checkboxes = array_values($this->form_checkboxes); // Reset keys
     }
 
     /**
@@ -251,7 +294,7 @@ class Search
      */
     public function setRepository($repository)
     {
-        if (in_array($repository, Project::getRepositories())) {
+        if (Project::isValidRepository($repository)) {
             $this->repository = $repository;
         }
 
@@ -266,5 +309,93 @@ class Search
     public function getRepository()
     {
         return $this->repository;
+    }
+
+    /**
+     * Set the type of search we want to perform
+     *
+     * @param  string $type The type of search we will perform
+     * @return $this
+     */
+    public function setSearchType($type)
+    {
+        if (in_array($type, $this->search_types)) {
+            $this->search_type = $type;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the type of search we want to perform
+     *
+     * @return string Type of search
+     */
+    public function getSearchType()
+    {
+        return $this->search_type;
+    }
+
+    /**
+     * Get all the types of search we can perform
+     *
+     * @return array Types of search
+     */
+    public function getSearchTypes()
+    {
+        return $this->search_types;
+    }
+
+    /**
+     * Get all the options we use in the search form
+     *
+     * @return array Form options
+     */
+    public function getFormSearchOptions()
+    {
+        return $this->form_search_options;
+    }
+
+    /**
+     * Get all the checkboxes we use in the search form
+     *
+     * @return array Form checkboxes
+     */
+    public function getFormCheckboxes()
+    {
+        return $this->form_checkboxes;
+    }
+
+    /**
+     * Set the Locales we will use for the search
+     *
+     * @param  array $locales The locale codes
+     * @return $this
+     */
+    public function setLocales($locales)
+    {
+        // We only allow up to 3 locales for analysis
+        $locales = array_slice($locales, 0, 3);
+
+        if (count($locales) == 3) {
+            // We check if the 3rd locale is the same as the 2nd one
+            if ($locales[2] == $locales[1]) {
+                unset($locales[2]);
+            }
+        }
+
+        $this->locales = $locales;
+
+        return $this;
+    }
+
+    /**
+     * Get the locales used for searching
+     *
+     * @return array Locale codes
+     */
+    public function getLocales()
+    {
+        return $this->locales;
     }
 }

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -367,35 +367,49 @@ class Search
     }
 
     /**
-     * Set the Locales we will use for the search
+     * Set the locales we will use for the search with this structure:
+     * $this->locales =
+     * [
+     * 	   'source' => 'en-US',
+     * 	   'target' => 'de',
+     * 	   'extra'  => 'ar',
+     * ];
+     *
+     * The 'extra' value is optional and used in views comparing
+     * data for 3 locales.
      *
      * @param  array $locales The locale codes
      * @return $this
      */
-    public function setLocales($locales)
+    public function setLocales(array $locales)
     {
         // We only allow up to 3 locales for analysis
         $locales = array_slice($locales, 0, 3);
 
+        $this->locales = [
+            'source' => $locales[0],
+            'target' => $locales[1],
+        ];
+
         if (count($locales) == 3) {
             // We check if the 3rd locale is the same as the 2nd one
-            if ($locales[2] == $locales[1]) {
-                unset($locales[2]);
+            if ($locales[2] != $locales[1]) {
+                $this->locales['extra'] = $locales[2];
             }
         }
-
-        $this->locales = $locales;
 
         return $this;
     }
 
     /**
-     * Get the locales used for searching
+     * Get a locale used for searching
      *
-     * @return array Locale codes
+     * @param  string $type The type of locale we want, can be
+     *                      'source', 'target' or 'extra'.
+     * @return string Locale code or an empty string
      */
-    public function getLocales()
+    public function getLocale($type)
     {
-        return $this->locales;
+        return isset($this->locales[$type]) ? $this->locales[$type] : '';
     }
 }

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -239,19 +239,21 @@ class ShowResults
      *
      * @param object $search_object  The Search object that contains all the options for the query
      * @param array  $search_results List of rows
+     * @param string $page           The page we are generating, used to output results for 2 or 3 locales
      *
      * @return string html table to insert in the view
      */
-    public static function resultsTable($search_object, $search_results)
+    public static function resultsTable($search_object, $search_results, $page)
     {
-        $locale1    = $search_object->getLocale('source');
-        $locale2    = $search_object->getLocale('target');
-        $direction1 = RTLSupport::getDirection($locale1);
-        $direction2 = RTLSupport::getDirection($locale2);
+        $locale1      = $search_object->getLocale('source');
+        $locale2      = $search_object->getLocale('target');
+        $direction1   = RTLSupport::getDirection($locale1);
+        $direction2   = RTLSupport::getDirection($locale2);
+        $extra_locale = ($page == '3locales');
 
         $extra_column_header = '';
 
-        if ($search_object->getLocale('extra') != '') {
+        if ($extra_locale) {
             $locale3    = $search_object->getLocale('extra');
             $direction3 = RTLSupport::getDirection($locale3);
             $extra_column_header = "<th>{$locale3}</th>";
@@ -298,7 +300,7 @@ class ShowResults
                 $locale2, $key, $source_string, $target_string, $current_repo, $entity_link
             )];
 
-            if ($search_object->getLocale('extra') != '') {
+            if ($extra_locale) {
                 $target_string2 = trim($strings[2]);
                 $entity_link = "?sourcelocale={$locale1}"
                                 . "&locale={$search_object->getLocale('extra')}"
@@ -314,7 +316,7 @@ class ShowResults
             foreach ($search as $val) {
                 $source_string = Utils::markString($val, $source_string);
                 $target_string = Utils::markString($val, $target_string);
-                if ($search_object->getLocale('extra') != '') {
+                if ($extra_locale) {
                     $target_string2 = Utils::markString($val, $target_string2);
                 }
             }
@@ -325,7 +327,7 @@ class ShowResults
             $source_string = Utils::highlightString($source_string);
             $target_string = Utils::highlightString($target_string);
 
-            if ($search_object->getLocale('extra') != '') {
+            if ($extra_locale) {
                 $target_string2 = htmlspecialchars($target_string2);
                 $target_string2 = Utils::highlightString($target_string2);
             }
@@ -397,7 +399,7 @@ class ShowResults
             $clipboard_target_string  = 'clip_' . md5($target_string);
 
             // 3locales view
-            if ($search_object->getLocale('extra') != '') {
+            if ($extra_locale) {
                 if (in_array($current_repo, ['firefox_ios', 'mozilla_org'])) {
                     $locale3_path = VersionControl::gitPath($locale3, $current_repo, $key);
                 } else {

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -244,15 +244,15 @@ class ShowResults
      */
     public static function resultsTable($search_object, $search_results)
     {
-        $locale1    = $search_object->getLocales()[0];
-        $locale2    = $search_object->getLocales()[1];
+        $locale1    = $search_object->getLocale('source');
+        $locale2    = $search_object->getLocale('target');
         $direction1 = RTLSupport::getDirection($locale1);
         $direction2 = RTLSupport::getDirection($locale2);
 
         $extra_column_header = '';
 
-        if (isset($search_object->getLocales()[2])) {
-            $locale3    = $search_object->getLocales()[2];
+        if ($search_object->getLocale('extra') != '') {
+            $locale3    = $search_object->getLocale('extra');
             $direction3 = RTLSupport::getDirection($locale3);
             $extra_column_header = "<th>{$locale3}</th>";
         }
@@ -269,9 +269,9 @@ class ShowResults
                      <tbody>\n";
 
         if (! $search_object->isWholeWords() && ! $search_object->isPerfectMatch()) {
-            $recherche = Utils::uniqueWords($search_object->getSearchTerms());
+            $search = Utils::uniqueWords($search_object->getSearchTerms());
         } else {
-            $recherche = [$search_object->getSearchTerms()];
+            $search = [$search_object->getSearchTerms()];
         }
 
         $current_repo = $search_object->getRepository();
@@ -282,7 +282,7 @@ class ShowResults
             if ($search_object->getSearchType() == 'strings') {
                 $result_entity = self::formatEntity($key);
             } else {
-                $result_entity = self::formatEntity($key, $recherche[0]);
+                $result_entity = self::formatEntity($key, $search[0]);
             }
 
             $component = explode('/', $key)[0];
@@ -298,23 +298,23 @@ class ShowResults
                 $locale2, $key, $source_string, $target_string, $current_repo, $entity_link
             )];
 
-            if (isset($search_object->getLocales()[2])) {
+            if ($search_object->getLocale('extra') != '') {
                 $target_string2 = trim($strings[2]);
                 $entity_link = "?sourcelocale={$locale1}"
-                                . "&locale={$search_object->getLocales()[2]}"
+                                . "&locale={$search_object->getLocale('extra')}"
                                 . "&repo={$current_repo}"
                                 . "&search_type=entities&recherche={$key}";
                 $bz_link[] = Bugzilla::reportErrorLink(
-                    $search_object->getLocales()[2], $key, $source_string, $target_string2, $current_repo, $entity_link
+                    $search_object->getLocale('extra'), $key, $source_string, $target_string2, $current_repo, $entity_link
                 );
             } else {
                 $target_string2 = '';
             }
 
-            foreach ($recherche as $val) {
+            foreach ($search as $val) {
                 $source_string = Utils::markString($val, $source_string);
                 $target_string = Utils::markString($val, $target_string);
-                if (isset($search_object->getLocales()[2])) {
+                if ($search_object->getLocale('extra') != '') {
                     $target_string2 = Utils::markString($val, $target_string2);
                 }
             }
@@ -325,7 +325,7 @@ class ShowResults
             $source_string = Utils::highlightString($source_string);
             $target_string = Utils::highlightString($target_string);
 
-            if (isset($search_object->getLocales()[2])) {
+            if ($search_object->getLocale('extra') != '') {
                 $target_string2 = htmlspecialchars($target_string2);
                 $target_string2 = Utils::highlightString($target_string2);
             }
@@ -397,7 +397,7 @@ class ShowResults
             $clipboard_target_string  = 'clip_' . md5($target_string);
 
             // 3locales view
-            if (isset($search_object->getLocales()[2])) {
+            if ($search_object->getLocale('extra') != '') {
                 if (in_array($current_repo, ['firefox_ios', 'mozilla_org'])) {
                     $locale3_path = VersionControl::gitPath($locale3, $current_repo, $key);
                 } else {

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -237,29 +237,27 @@ class ShowResults
     /**
      * Html table of search results used by the main view (needs a lot of refactoring)
      *
-     * @param array  $search_id      Identifier for the current search
+     * @param object $search_object  The Search object that contains all the options for the query
      * @param array  $search_results List of rows
-     * @param string $recherche      The words searched for
-     * @param string $locale1        Reference locale to search in, usually en-US
-     * @param string $locale2        Target locale to search in
-     * @param array  $search_options All the search options from the query
      *
      * @return string html table to insert in the view
      */
-    public static function resultsTable($search_id, $search_results, $recherche, $locale1, $locale2, $search_options)
+    public static function resultsTable($search_object, $search_results)
     {
+        $locale1    = $search_object->getLocales()[0];
+        $locale2    = $search_object->getLocales()[1];
         $direction1 = RTLSupport::getDirection($locale1);
         $direction2 = RTLSupport::getDirection($locale2);
 
-        if (isset($search_options['extra_locale'])) {
-            $locale3    = $search_options['extra_locale'];
+        $extra_column_header = '';
+
+        if (isset($search_object->getLocales()[2])) {
+            $locale3    = $search_object->getLocales()[2];
             $direction3 = RTLSupport::getDirection($locale3);
             $extra_column_header = "<th>{$locale3}</th>";
-        } else {
-            $extra_column_header = '';
         }
 
-        $table  = "<table class='collapsable results_table {$search_id}'>
+        $table  = "<table class='collapsable results_table'>
                      <thead>
                        <tr class='column_headers'>
                          <th>Entity</th>
@@ -270,18 +268,18 @@ class ShowResults
                      </thead>
                      <tbody>\n";
 
-        if (!$search_options['whole_word'] && !$search_options['perfect_match']) {
-            $recherche = Utils::uniqueWords($recherche);
+        if (! $search_object->isWholeWords() && ! $search_object->isPerfectMatch()) {
+            $recherche = Utils::uniqueWords($search_object->getSearchTerms());
         } else {
-            $recherche = [$recherche];
+            $recherche = [$search_object->getSearchTerms()];
         }
 
-        $current_repo = $search_options['repo'];
+        $current_repo = $search_object->getRepository();
 
         foreach ($search_results as $key => $strings) {
 
             // Don't highlight search matches in entities when searching strings
-            if ($search_options['search_type'] == 'strings') {
+            if ($search_object->getSearchType() == 'strings') {
                 $result_entity = self::formatEntity($key);
             } else {
                 $result_entity = self::formatEntity($key, $recherche[0]);
@@ -300,14 +298,14 @@ class ShowResults
                 $locale2, $key, $source_string, $target_string, $current_repo, $entity_link
             )];
 
-            if (isset($search_options['extra_locale'])) {
+            if (isset($search_object->getLocales()[2])) {
                 $target_string2 = trim($strings[2]);
                 $entity_link = "?sourcelocale={$locale1}"
-                                . "&locale={$search_options['extra_locale']}"
+                                . "&locale={$search_object->getLocales()[2]}"
                                 . "&repo={$current_repo}"
                                 . "&search_type=entities&recherche={$key}";
                 $bz_link[] = Bugzilla::reportErrorLink(
-                    $search_options['extra_locale'], $key, $source_string, $target_string2, $current_repo, $entity_link
+                    $search_object->getLocales()[2], $key, $source_string, $target_string2, $current_repo, $entity_link
                 );
             } else {
                 $target_string2 = '';
@@ -316,7 +314,7 @@ class ShowResults
             foreach ($recherche as $val) {
                 $source_string = Utils::markString($val, $source_string);
                 $target_string = Utils::markString($val, $target_string);
-                if (isset($search_options["extra_locale"])) {
+                if (isset($search_object->getLocales()[2])) {
                     $target_string2 = Utils::markString($val, $target_string2);
                 }
             }
@@ -327,7 +325,7 @@ class ShowResults
             $source_string = Utils::highlightString($source_string);
             $target_string = Utils::highlightString($target_string);
 
-            if (isset($search_options["extra_locale"])) {
+            if (isset($search_object->getLocales()[2])) {
                 $target_string2 = htmlspecialchars($target_string2);
                 $target_string2 = Utils::highlightString($target_string2);
             }
@@ -378,15 +376,17 @@ class ShowResults
             }
 
             // Missing string error
-            if (!$source_string) {
+            if (! $source_string) {
                 $source_string = '<em class="error">warning: missing string</em>';
                 $error_message = '';
             }
-            if (!$target_string) {
+
+            if (! $target_string) {
                 $target_string = '<em class="error">warning: missing string</em>';
                 $error_message = '';
             }
-            if (!$target_string2) {
+
+            if (! $target_string2) {
                 $target_string2 = '<em class="error">warning: missing string</em>';
                 $error_message = '';
             }
@@ -397,7 +397,7 @@ class ShowResults
             $clipboard_target_string  = 'clip_' . md5($target_string);
 
             // 3locales view
-            if (isset($search_options["extra_locale"])) {
+            if (isset($search_object->getLocales()[2])) {
                 if (in_array($current_repo, ['firefox_ios', 'mozilla_org'])) {
                     $locale3_path = VersionControl::gitPath($locale3, $current_repo, $key);
                 } else {
@@ -425,7 +425,7 @@ class ShowResults
                 $extra_column_rows = '';
             }
             $table .= "
-                <tr class='{$component} {$search_id}'>
+                <tr class='{$component}'>
                   <td>
                     <span class='celltitle'>Entity</span>
                     <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -56,7 +56,7 @@ if ($url['path'] == '3locales') {
 require_once VIEWS . 'search_form.php';
 
 // Count the number of requests we receive
-if ($initial_search != '') {
+if ($search->getSearchTerms() != '') {
     include INC . 'search_counter.php';
 }
 
@@ -82,7 +82,7 @@ if ($check['t2t']) {
     $tmx_source = Utils::getRepoStrings($source_locale, $search->getRepository());
     $tmx_target = Utils::getRepoStrings($locale, $search->getRepository());
 
-    if ($check['search_type'] == 'entities') {
+    if ($search->getSearchType() == 'entities') {
         require_once MODELS . 'mainsearch_entities.php';
         require_once VIEWS . 'results_entities.php';
     } else {

--- a/app/inc/l10n-init.php
+++ b/app/inc/l10n-init.php
@@ -4,14 +4,9 @@ namespace Transvision;
 // This file initializes l10n support: locale detection, RTL/LTR variables
 
 if (isset($_GET['repo'])) {
-    $repo = Project::isValidRepository($_GET['repo'])
-            ? $_GET['repo']
-            : 'aurora';
-} else {
-    if (! isset($repo)) {
-        $repo = 'aurora';
-    }
+    $search->setRepository(Utils::secureText($_GET['repo']));
 }
+$repo = $search->getRepository();
 
 $all_locales = Project::getRepositoryLocales($repo);
 

--- a/app/inc/search_counter.php
+++ b/app/inc/search_counter.php
@@ -20,11 +20,11 @@ $stats = $json_data
     ->fetchContent();
 
 foreach ($check as $k => $v) {
-    if (in_array($k, $form_checkboxes) && $v == 1) {
+    if (in_array($k, $search->getFormCheckboxes()) && $v == 1) {
         $stats[$k] = array_key_exists($k, $stats) ? $stats[$k] += 1 : 1;
     }
 
-    if (in_array($k, array_diff($form_search_options, $form_checkboxes))) {
+    if (in_array($k, array_diff($search->getFormSearchOptions(), $search->getFormCheckboxes()))) {
         $stats[$v] = array_key_exists($v, $stats) ? $stats[$v] += 1 : 1;
     }
 

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -5,41 +5,24 @@ namespace Transvision;
 $_GET['recherche'] = isset($_GET['recherche']) ? $_GET['recherche'] : '';
 $my_search = Utils::cleanString($_GET['recherche']);
 
-// Cloned value for reference
-$initial_search = $my_search;
-$initial_search_decoded = htmlentities($initial_search);
-
 // Checkboxes states
 $check = [];
 
-foreach ($form_checkboxes as $val) {
+foreach ($search->getFormCheckboxes() as $val) {
     $check[$val] = isset($_GET[$val]);
 }
 
-/*
-    We don't set a default repository because we always have a default fallback
-    value in the Search object, but we need to define it to avoid a warning.
-*/
-$check['repo'] = '';
-
-// Check for default_repository cookie
-if (isset($_COOKIE['default_repository'])) {
-    $check['repo'] = $_COOKIE['default_repository'];
+// Check for default_repository cookie if we don't have a GET value
+if (! isset($_GET['repo']) && isset($_COOKIE['default_repository'])) {
+    $repo = $_COOKIE['default_repository'];
 }
 
-// Check if we have a GET parameter that would override the cookie
-if (isset($_GET['repo'])) {
-    $check['repo'] = Utils::secureText($_GET['repo']);
-}
-
-// Default search type: strings
-$check['search_type'] = 'strings';
-if (isset($_GET['search_type'])
-    && in_array($_GET['search_type'], ['strings', 'entities', 'strings_entities']
-    )) {
-    $check['search_type'] = $_GET['search_type'];
+if (isset($_GET['search_type'])) {
+    $search_type = Utils::secureText($_GET['search_type']);
 } elseif (isset($_COOKIE['default_search_type'])) {
-    $check['search_type'] = $_COOKIE['default_search_type'];
+    $search_type = $_COOKIE['default_search_type'];
+} else {
+    $search_type = $search->getSearchType();
 }
 
 // Define our regex and search parameters
@@ -48,36 +31,38 @@ $search
     ->setRegexWholeWords($check['whole_word'])
     ->setRegexCaseInsensitive($check['case_sensitive'])
     ->setRegexPerfectMatch($check['perfect_match'])
-    ->setRepository($check['repo']);
+    ->setRepository($repo)
+    ->setSearchType($search_type)
+    ->setLocales([$source_locale, $locale, $locale2]);
 
 // Build the repository switcher
-$repo_list = Utils::getHtmlSelectOptions($repos_nice_names, $search->getRepository(), true);
+$repo_list = Utils::getHtmlSelectOptions(
+    $repos_nice_names,
+    $search->getRepository(),
+    true
+);
 
-// Get the locale list for every repo and build his target/source locale switcher values.
-$loc_list = [];
+// Get the locale list for every repo and build its target/source locale switcher values.
 $source_locales_list = [];
 $target_locales_list = [];
-$repositories = Project::getRepositories();
-foreach ($repositories as $repository) {
-    $loc_list[$repository] = Project::getRepositoryLocales($repository);
 
-    // Build the source locale switcher
-    $source_locales_list[$repository] = Utils::getHtmlSelectOptions(
-        $loc_list[$repository],
-        Project::getLocaleInContext($source_locale, $repository)
-    );
+foreach (Project::getRepositories() as $repository) {
+    // Closure to build the source locale switcher
+    $select_options = function ($locale) use ($repository) {
+        return Utils::getHtmlSelectOptions(
+            Project::getRepositoryLocales($repository),
+            Project::getLocaleInContext($locale, $repository)
+        );
+    };
 
-    // Build the target locale switcher
-    $target_locales_list[$repository] = Utils::getHtmlSelectOptions(
-        $loc_list[$repository],
-        Project::getLocaleInContext($locale, $repository)
-    );
+    // Build the source locale HTML switcher
+    $source_locales_list[$repository] = $select_options($source_locale);
 
-    // 3locales view: build the target locale switcher for a second locale
-    $target_locales_list2[$repository] = Utils::getHtmlSelectOptions(
-        $loc_list[$repository],
-        Project::getLocaleInContext($locale2, $repository)
-    );
+    // Build the target locale HTML switcher
+    $target_locales_list[$repository] = $select_options($locale);
+
+    // 3locales view: build the target locale HTML switcher for a second locale
+    $target_locales_list2[$repository] = $select_options($locale2);
 }
 
 // Build the search type switcher
@@ -89,17 +74,19 @@ $search_type_descriptions = [
 
 $search_type_list = Utils::getHtmlSelectOptions(
     $search_type_descriptions,
-    $check['search_type'],
+    $search->getSearchType(),
     true
 );
 
-// Get COOKIES
+// Get status of cookies
 $get_cookie = function ($var) {
     return isset($_COOKIE[$var]) ? $_COOKIE[$var] : '';
 };
 
-$cookie_repository     = $get_cookie('default_repository');
-$cookie_source_locale  = $get_cookie('default_source_locale');
-$cookie_target_locale  = $get_cookie('default_target_locale');
-$cookie_target_locale2 = $get_cookie('default_target_locale2');
-$cookie_search_type    = $get_cookie('default_search_type');
+$cookies = [
+    'repository'     => $get_cookie('default_repository'),
+    'source_locale'  => $get_cookie('default_source_locale'),
+    'target_locale'  => $get_cookie('default_target_locale'),
+    'target_locale2' => $get_cookie('default_target_locale2'),
+    'search_type'    => $get_cookie('default_search_type'),
+];

--- a/app/inc/variables.php
+++ b/app/inc/variables.php
@@ -8,8 +8,3 @@ $repos            = Project::getRepositories();
 $repos_nice_names = Project::getRepositoriesNames();
 $gaia_repos       = Project::getGaiaRepositories();
 $desktop_repos    = Project::getDesktopRepositories();
-
-// Search forms
-$form_search_options = ['case_sensitive', 'whole_word', 'perfect_match',
-                        't2t', 'repo', 'search_type', ];
-$form_checkboxes = array_diff($form_search_options, ['repo', 'search_type']);

--- a/app/models/3locales_search.php
+++ b/app/models/3locales_search.php
@@ -7,7 +7,7 @@ if ($search->isPerfectMatch()) {
     $locale3_strings = $search->grep($tmx_target2);
 } else {
     $locale3_strings = $tmx_target2;
-    foreach (Utils::uniqueWords($initial_search) as $word) {
+    foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
         $search->setRegexSearchTerms($word);
         $locale3_strings = $search->grep($locale3_strings);
     }

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -29,7 +29,7 @@ $search
 
 // We loop through all repositories searched and merge results
 foreach ($repositories as $repository) {
-    $source_strings = Utils::getRepoStrings($search->getLocales()[0], $repository);
+    $source_strings = Utils::getRepoStrings($search->getLocale('source'), $repository);
 
     if ($search->isPerfectMatch()) {
         if ($search->getSearchType() == 'entities') {
@@ -54,7 +54,7 @@ foreach ($repositories as $repository) {
 
     // We have our list of filtered source strings, get corresponding target locale strings
     $target_strings = array_intersect_key(
-        Utils::getRepoStrings($search->getLocales()[1], $repository),
+        Utils::getRepoStrings($search->getLocale('target'), $repository),
         array_flip($entities)
     );
 

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -10,9 +10,6 @@ $get_option = function ($option) use ($request) {
     return false;
 };
 
-// Get all strings
-$initial_search = urldecode(Utils::cleanString($request->parameters[6]));
-
 $repositories = $request->parameters[3] == 'global'
     ? Project::getRepositories()
     : [$request->parameters[3]];
@@ -21,20 +18,21 @@ $entities_merged       = [];
 $source_strings_merged = [];
 $target_strings_merged = [];
 
-// Define our regex
+// Define our search terms and parameters
 $search
-    ->setSearchTerms(Utils::cleanString($initial_search))
+    ->setSearchTerms(urldecode(Utils::cleanString($request->parameters[6])))
     ->setRegexWholeWords($get_option('whole_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexPerfectMatch($get_option('perfect_match'))
-    ->setRepository($request->parameters[3]);
+    ->setSearchType($request->parameters[2])
+    ->setLocales([$request->parameters[4], $request->parameters[5]]);
 
 // We loop through all repositories searched and merge results
 foreach ($repositories as $repository) {
-    $source_strings = Utils::getRepoStrings($request->parameters[4], $repository);
+    $source_strings = Utils::getRepoStrings($search->getLocales()[0], $repository);
 
     if ($search->isPerfectMatch()) {
-        if ($request->parameters[2] == 'entities') {
+        if ($search->getSearchType() == 'entities') {
             $entities = ShowResults::searchEntities($source_strings, $search->getRegex());
             $source_strings = array_intersect_key($source_strings, array_flip($entities));
         } else {
@@ -42,9 +40,9 @@ foreach ($repositories as $repository) {
             $entities = array_keys($source_strings);
         }
     } else {
-        foreach (Utils::uniqueWords($initial_search) as $word) {
+        foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
             $search->setRegexSearchTerms($word);
-            if ($request->parameters[2] == 'entities') {
+            if ($search->getSearchType() == 'entities') {
                 $entities = ShowResults::searchEntities($source_strings, $search->getRegex());
                 $source_strings = array_intersect_key($source_strings, array_flip($entities));
             } else {
@@ -56,7 +54,7 @@ foreach ($repositories as $repository) {
 
     // We have our list of filtered source strings, get corresponding target locale strings
     $target_strings = array_intersect_key(
-        Utils::getRepoStrings($request->parameters[5], $repository),
+        Utils::getRepoStrings($search->getLocales()[1], $repository),
         array_flip($entities)
     );
 

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -29,14 +29,14 @@ $terms = Utils::uniqueWords($search->getSearchTerms());
 
  // Loop through all repositories searching in both source and target languages
 foreach ($repositories as $repository) {
-    $source_strings = Utils::getRepoStrings($search->getLocales()[0], $repository);
+    $source_strings = Utils::getRepoStrings($search->getLocale('source'), $repository);
     foreach ($terms as $word) {
         $search->setRegexSearchTerms($word);
         $source_strings = $search->grep($source_strings);
     }
     $source_strings_merged = array_merge($source_strings, $source_strings_merged);
 
-    $target_strings = Utils::getRepoStrings($search->getLocales()[1], $repository);
+    $target_strings = Utils::getRepoStrings($search->getLocale('target'), $repository);
     foreach ($terms as $word) {
         $search->setRegexSearchTerms($word);
         $target_strings = $search->grep($target_strings);

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -29,7 +29,7 @@ $search
 
 // We loop through all repositories and merge the results
 foreach ($repositories as $repository) {
-    $source_strings = Utils::getRepoStrings($search->getLocales()[0], $repository);
+    $source_strings = Utils::getRepoStrings($search->getLocale('source'), $repository);
 
     foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
         $search->setRegexSearchTerms($word);
@@ -48,7 +48,7 @@ foreach ($repositories as $repository) {
         We are only interested in target strings with keys in common with our
         source strings.
     */
-    $target_strings = Utils::getRepoStrings($search->getLocales()[1], $repository);
+    $target_strings = Utils::getRepoStrings($search->getLocale('target'), $repository);
 
     foreach ($source_strings as $key => $value) {
         if (isset($target_strings[$key]) && ! empty($target_strings[$key])) {

--- a/app/models/mainsearch_entities.php
+++ b/app/models/mainsearch_entities.php
@@ -18,7 +18,7 @@ $entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
 if (count($entities) == 0) {
     $merged_strings = [];
 
-    $best_matches = Strings::getSimilar($initial_search, array_keys($tmx_source), 3);
+    $best_matches = Strings::getSimilar($search->getSearchTerms(), array_keys($tmx_source), 3);
 
     include VIEWS . 'results_similar.php';
 

--- a/app/models/mainsearch_glossary.php
+++ b/app/models/mainsearch_glossary.php
@@ -5,7 +5,7 @@ namespace Transvision;
 $tmx_source = Utils::getRepoStrings($source_locale, $search->getRepository());
 $tmx_target = Utils::getRepoStrings($locale, $search->getRepository());
 $locale1_strings = $tmx_source;
-$search_terms = Utils::uniqueWords($initial_search);
+$search_terms = Utils::uniqueWords($search->getSearchTerms());
 
 foreach ($search_terms as $word) {
     $search->setRegexSearchTerms($word);

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -7,14 +7,14 @@ if ($search->isPerfectMatch()) {
 } else {
     $locale1_strings = $tmx_source;
     $locale2_strings = $tmx_target;
-    foreach (Utils::uniqueWords($initial_search) as $word) {
+    foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
         $search->setRegexSearchTerms($word);
         $locale1_strings = $search->grep($locale1_strings);
         $locale2_strings = $search->grep($locale2_strings);
     }
 }
 
-if ($check['search_type'] == 'strings_entities') {
+if ($search->getSearchType() == 'strings_entities') {
     $entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
     foreach ($entities as $entity) {
         $locale1_strings[$entity] = $tmx_source[$entity];
@@ -60,11 +60,11 @@ foreach ($searches as $key => $value) {
             : "<span class=\"results_count_{$search_id}\">" . Utils::pluralize(count($search_results), 'result') . '</span>';
 
         $output[$key] = "<h2>Displaying {$message_count} for the string "
-                        . "<span class=\"searchedTerm\">{$initial_search_decoded}</span> in {$key}:</h2>";
-        $output[$key] .= ShowResults::resultsTable($search_id, $search_results, $initial_search, $source_locale, $locale, $check);
+                        . "<span class=\"searchedTerm\">" . htmlentities($my_search) . "</span> in {$key}:</h2>";
+        $output[$key] .= ShowResults::resultsTable($search, $search_results);
     } else {
         $output[$key] = "<h2>No matching results for the string "
-                        . "<span class=\"searchedTerm\">{$initial_search_decoded}</span>"
+                        . "<span class=\"searchedTerm\">" . htmlentities($my_search) . "</span>"
                         . " for the locale {$key}</h2>";
     }
 }
@@ -80,7 +80,7 @@ if (! $search_yields_results) {
         $merged_strings = array_merge($merged_strings, array_values($values));
     }
 
-    $best_matches = Strings::getSimilar($initial_search, $merged_strings, 3);
+    $best_matches = Strings::getSimilar($search->getSearchTerms(), $merged_strings, 3);
 
     include VIEWS . 'results_similar.php';
 

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -45,7 +45,6 @@ $search_yields_results = false;
 
 // This will hold the components names for the search filters
 $components = [];
-
 foreach ($searches as $key => $value) {
     $search_results = ShowResults::getTMXResults(array_keys($value), $data);
     $components += Project::getComponents($search_results);
@@ -61,7 +60,7 @@ foreach ($searches as $key => $value) {
 
         $output[$key] = "<h2>Displaying {$message_count} for the string "
                         . "<span class=\"searchedTerm\">" . htmlentities($my_search) . "</span> in {$key}:</h2>";
-        $output[$key] .= ShowResults::resultsTable($search, $search_results);
+        $output[$key] .= ShowResults::resultsTable($search, $search_results, $page);
     } else {
         $output[$key] = "<h2>No matching results for the string "
                         . "<span class=\"searchedTerm\">" . htmlentities($my_search) . "</span>"

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -91,7 +91,7 @@ foreach ($entities as $entity) {
       <span class='celltitle'>Entity</span>
       <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
       <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$current_repo}' title='List all translations for this entity'>l10n</a>
-      <a class='link_to_entity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $initial_search) . "</a>
+      <a class='link_to_entity' href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $search->getSearchTerms()) . "</a>
     </td>
     <td dir='{$direction1}'>
       <span class='celltitle'>{$source_locale}</span>

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -15,7 +15,7 @@ foreach ($best_matches as $match) {
 
 <div class="resultsbox">
     <h3>There were no results for the string
-    <span class="searchedTerm"><?=$initial_search_decoded?></span>.
+    <span class="searchedTerm"><?=htmlentities($my_search)?></span>.
     <br>Possibly related searches:
     </h3>
 

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -5,6 +5,14 @@ namespace Transvision;
 $javascript_include[] = '/js/main_search.js';
 $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.min.js';
 
+/*
+    This function will mark a <select> option as selected if a cookie is set.
+*/
+$cookie_option = function ($cookie, $locale) use ($search) {
+    if (in_array($cookie, Project::getRepositoryLocales($search->getRepository()))) {
+        return Utils::checkboxDefaultOption($locale, $cookie);
+    }
+};
 ?>
   <div id="current">You are looking at the <em><?=$repos_nice_names[$search->getRepository()]?></em> channel <strong><?=$locale?></strong></div>
     <form name="searchform" id="searchform" method="get" action="./" >
@@ -15,7 +23,7 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                     <input type="text"
                            name="recherche"
                            id="recherche"
-                           value="<?=Utils::secureText($initial_search)?>"
+                           value="<?=Utils::secureText($search->getSearchTerms())?>"
                            placeholder="Type your search here"
                            title="Type your search here"
                            size="30"
@@ -23,7 +31,7 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                     <span id="clear_search" alt="Clear the search field" title="Clear the search field"></span>
                 </div>
                 <input type="submit" value="Search" alt="Search" />
-                <p id="searchcontext">Search will be performed on: <span id="searchcontextvalue"><?=$search_type_descriptions[$check['search_type']]?></span>.</p>
+                <p id="searchcontext">Search will be performed on: <span id="searchcontextvalue"><?=$search_type_descriptions[$search->getSearchType()]?></span>.</p>
             </div>
             <div id="searchoptions">
                 <fieldset>
@@ -32,14 +40,14 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                         id='repository'
                         name='repo'
                         title="Repository">
-                    <?=$repo_list?>
+                        <?=$repo_list?>
                     </select>
                     <label class="default_option" for="default_repository">
                         <input type="checkbox"
                                id="default_repository"
                                class="mainsearch_default_checkbox"
-                               value="<?=$cookie_repository?>"
-                               <?=Utils::checkboxDefaultOption($search->getRepository(), $cookie_repository)?>
+                               value="<?=$cookies['repository']?>"
+                               <?=Utils::checkboxDefaultOption($search->getRepository(), $cookies['repository'])?>
                          /> <span>Default</span>
                      </label>
                 </fieldset>
@@ -50,19 +58,14 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                         name='sourcelocale'
                         class='mainsearch_locale_selector'
                         title="Source Locale">
-                    <?=$source_locales_list[$search->getRepository()]?>
+                        <?=$source_locales_list[$search->getRepository()]?>
                     </select>
                     <label class="default_option" for="default_source_locale">
                         <input type="checkbox"
                                id="default_source_locale"
                                class="mainsearch_default_checkbox"
-                               value="<?=$cookie_source_locale?>"
-                                <?php
-                                // Mark as default only if the cookie_source_locale exist in repository array
-                                if (in_array($cookie_source_locale, $loc_list[$search->getRepository()])) {
-                                    echo Utils::checkboxDefaultOption($source_locale, $cookie_source_locale);
-                                }
-                                ?>
+                               value="<?=$cookies['source_locale']?>"
+                               <?=$cookie_option($cookies['source_locale'], $source_locale)?>
                          /> <span>Default</span>
                      </label>
                 </fieldset>
@@ -75,19 +78,14 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                         name='locale'
                         class='mainsearch_locale_selector'
                         title="Target Locale">
-                    <?=$target_locales_list[$search->getRepository()]?>
+                        <?=$target_locales_list[$search->getRepository()]?>
                     </select>
                     <label class="default_option" for="default_target_locale">
                         <input type="checkbox"
                                id="default_target_locale"
                                class="mainsearch_default_checkbox"
-                               value="<?=$cookie_target_locale?>"
-                                <?php
-                                // Mark as default only if the cookie_target_locale exist in repository array
-                                if (in_array($cookie_target_locale, $loc_list[$search->getRepository()])) {
-                                    echo Utils::checkboxDefaultOption($locale, $cookie_target_locale);
-                                }
-                                ?>
+                               value="<?=$cookies['target_locale']?>"
+                               <?=$cookie_option($cookies['target_locale'], $locale)?>
                          /> <span>Default</span>
                      </label>
                 </fieldset>
@@ -100,19 +98,14 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                         name='locale2'
                         class='mainsearch_locale_selector'
                         title="Extra Locale">
-                    <?=$target_locales_list2[$search->getRepository()]?>
+                        <?=$target_locales_list2[$search->getRepository()]?>
                     </select>
                     <label class="default_option" for="default_target_locale2">
                         <input type="checkbox"
                                id="default_target_locale2"
                                class="mainsearch_default_checkbox"
-                               value="<?=$cookie_target_locale2?>"
-                                <?php
-                                // Mark as default only if the cookie_target_locale exist in repository array
-                                if (in_array($cookie_target_locale2, $loc_list[$search->getRepository()])) {
-                                    echo Utils::checkboxDefaultOption($locale2, $cookie_target_locale2);
-                                }
-                                ?>
+                               value="<?=$cookies['target_locale2']?>"
+                               <?=$cookie_option($cookies['target_locale2'], $locale2)?>
                          /> <span>Default</span>
                      </label>
                 </fieldset>
@@ -130,8 +123,8 @@ $javascript_include[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.mi
                         <input type="checkbox"
                                id="default_search_type"
                                class="mainsearch_default_checkbox"
-                               value="<?=$cookie_search_type?>"
-                               <?=Utils::checkboxDefaultOption($check['search_type'], $cookie_search_type)?>
+                               value="<?=$cookies['search_type']?>"
+                               <?=Utils::checkboxDefaultOption($search->getSearchType(), $cookies['search_type'])?>
                          /> <span>Default</span>
                      </label>
                 </fieldset>

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -3,7 +3,6 @@ namespace Transvision;
 
 $source_locale  = isset($source_locale) ? $source_locale : 'en-US';
 $locale         = isset($locale) ? $locale : 'fr';
-$initial_search = isset($initial_search) ? $initial_search : 'Bookmarks';
 $base_js        = ['/js/base.js'];
 $base_css       = ['transvision.css'];
 $cache_bust     = '?v=' . VERSION;
@@ -42,7 +41,7 @@ $li_link = function ($page, $title, $text) use ($url, $urls) {
 $li_t2t = '<li><a ' . (isset($_GET['t2t']) ? 'class="selected_view" ' : '')
        . 'href="/?sourcelocale=' . $source_locale . '&locale=' . $locale
        . '&repo=' . $search->getRepository() . '&t2t=t2t&recherche='
-       . Utils::secureText($initial_search)
+       . Utils::secureText($search->getSearchTerms())
        . '" title="Search in the Glossary">Glossary</a></li>';
 
 $links = <<<EOT

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -32,6 +32,18 @@ class Search extends atoum\test
         $this
             ->string($obj->getRepository())
                 ->isEqualTo('aurora');
+        $this
+            ->string($obj->getSearchType())
+                ->isEqualTo('strings');
+        $this
+            ->array($obj->getLocales())
+                ->isEqualTo([]);
+        $this
+            ->array($obj->getFormSearchOptions())
+                ->isEqualTo(['case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'whole_word']);
+        $this
+            ->array($obj->getFormCheckboxes())
+                ->isEqualTo(['case_sensitive', 'perfect_match', 't2t', 'whole_word']);
     }
 
     public function testSetSearchTerms()
@@ -179,5 +191,36 @@ class Search extends atoum\test
         $obj->setRepository('release');
         $this->string($obj->getRepository())
             ->isEqualTo('release');
+    }
+
+    public function testSetSearchType()
+    {
+        $obj = new _Search();
+        $obj->setSearchType('foobar');
+        $this->string($obj->getSearchType())
+            ->isEqualTo('strings');
+
+        $obj->setSearchType('entities');
+        $this->string($obj->getSearchType())
+            ->isEqualTo('entities');
+    }
+
+    public function testGetSearchTypes()
+    {
+        $obj = new _Search();
+        $this->array($obj->getSearchTypes())
+            ->isEqualTo(['strings', 'entities', 'strings_entities']);
+    }
+
+    public function testSetLocales()
+    {
+        $obj = new _Search();
+        $obj->setLocales(['en-US', 'fr', 'de', 'it']);
+        $this->array($obj->getLocales())
+            ->hasSize(3);
+
+        $obj->setLocales(['en-US', 'fr', 'fr']);
+        $this->array($obj->getLocales())
+            ->isEqualTo(['en-US', 'fr']);
     }
 }

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -36,8 +36,8 @@ class Search extends atoum\test
             ->string($obj->getSearchType())
                 ->isEqualTo('strings');
         $this
-            ->array($obj->getLocales())
-                ->isEqualTo([]);
+            ->string($obj->getLocale('source'))
+                ->isEqualTo('');
         $this
             ->array($obj->getFormSearchOptions())
                 ->isEqualTo(['case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'whole_word']);
@@ -216,11 +216,19 @@ class Search extends atoum\test
     {
         $obj = new _Search();
         $obj->setLocales(['en-US', 'fr', 'de', 'it']);
-        $this->array($obj->getLocales())
-            ->hasSize(3);
+        $this->string($obj->getLocale('source'))
+            ->isEqualTo('en-US');
+        $this->string($obj->getLocale('target'))
+            ->isEqualTo('fr');
+        $this->string($obj->getLocale('extra'))
+            ->isEqualTo('de');
 
         $obj->setLocales(['en-US', 'fr', 'fr']);
-        $this->array($obj->getLocales())
-            ->isEqualTo(['en-US', 'fr']);
+        $this->string($obj->getLocale('source'))
+            ->isEqualTo('en-US');
+        $this->string($obj->getLocale('target'))
+            ->isEqualTo('fr');
+        $this->string($obj->getLocale('extra'))
+            ->isEqualTo('');
     }
 }


### PR DESCRIPTION
New methods in Search class:
* setSearchType($type)
* getSearchType()
* getSearchTypes()
* getFormSearchOptions()
* setLocales()
* getLocale()
* getFormSearchOptions()
* getFormCheckboxes()

Other changes:
* Only one array $cookies storing all cookies values
* Suppression of several global variables
* Refactoring of search_options.php and search_forms.php to use lambdas and remove code duplication
* ShowResults::resultsTable() now takes the $search object as a parameter

Generally speaking, it makes our core code simpler and hopefully easier to make evolve.