### PR TITLE
Remove Venkman support

### DIFF
--- a/app/classes/Transvision/VersionControl.php
+++ b/app/classes/Transvision/VersionControl.php
@@ -151,25 +151,9 @@ class VersionControl
                 $url .= '/releases/l10n/mozilla-' . $repo . '/' . $locale . '/file/default/';
             }
         } else {
-            // Chatzilla and Venkman are in separate repositories
-            if ($base_folder == 'extensions') {
-                switch ($exploded_path[1]) {
-                    case 'irc':
-                        $url .= '/chatzilla';
-                        $found_extension = true;
-                        break;
-                    case 'venkman':
-                        $url .= '/venkman';
-                        $found_extension = true;
-                        break;
-                    default:
-                        $found_extension = false;
-                        break;
-                }
-
-                if ($found_extension) {
-                    return "{$url}/file/default/locales/en-US/chrome/{$entity_file}";
-                }
+            // ChatZilla is in a separate repository
+            if ($base_folder == 'extensions' && $exploded_path[1] == 'irc') {
+                return "{$url}/chatzilla/file/default/locales/en-US/chrome/{$entity_file}";
             }
 
             // comm-central folders

--- a/app/scripts/glossaire.sh
+++ b/app/scripts/glossaire.sh
@@ -399,7 +399,6 @@ function updateFirefoxiOS() {
 
 # Update repos without branches first (their TMX is created in updateStandardRepo)
 updateNoBranchRepo "chatzilla"
-updateNoBranchRepo "venkman"
 
 updateStandardRepo "release" "release"
 updateStandardRepo "beta" "beta"

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -53,18 +53,13 @@ function createSymlinks() {
         done
         ;;
 
-        "chatzilla" | "venkman")
-        # Restructure chatzilla and venkman
+        "chatzilla" )
+        # Restructure ChatZilla
         for branch in "${branches[@]}"
         do
-            if [ "$1" == "chatzilla" ]
-            then
-                # Source repo is called "chatzilla", l10n folder is "irc"
-                local dir="extensions/irc/locales/en-US"
-            else
-                local dir="extensions/$1/locales/en-US"
-            fi
-            repo_name="$1/locales/en-US"
+            # Source repo is called "chatzilla", l10n folder is "irc"
+            local dir="extensions/irc/locales/en-US"
+            repo_name="chatzilla/locales/en-US"
             path="$local_hg/${branch^^}_EN-US/COMMUN/$dir"
             if [ ! -L "$path/en-US" ]
             then
@@ -148,10 +143,10 @@ function initDesktopSourceRepo() {
             hg clone https://hg.mozilla.org/mozilla-central/
         fi
 
-        # Checkout chatzilla and venkman only on trunk, since they don't
-        # have branches. Can add other products to array nobranch_products,
-        # as long as their code is located in https://hg.mozilla.org/PRODUCT
-        local nobranch_products=( chatzilla venkman )
+        # Checkout ChatZilla only on trunk, since they don't have branches.
+        # Can add other products to array nobranch_products, as long
+        # as their code is located in https://hg.mozilla.org/PRODUCT
+        local nobranch_products=( chatzilla )
         for product in "${nobranch_products[@]}"
         do
             if [ ! -d $trunk_source/$product/.hg ]
@@ -294,7 +289,6 @@ initDesktopL10nRepo "aurora"
 createSymlinks "mozilla"
 createSymlinks "comm"
 createSymlinks "chatzilla"
-createSymlinks "venkman"
 
 # Set up all Gaia versions
 for gaia_version in $(cat ${gaia_versions})

--- a/tests/units/Transvision/VersionControl.php
+++ b/tests/units/Transvision/VersionControl.php
@@ -131,12 +131,6 @@ class VersionControl extends atoum\test
             ],
             [
                 'en-US',
-                'beta',
-                'extensions/venkman/chrome/venkman.dtd:Help.about',
-                'https://hg.mozilla.org/venkman/file/default/locales/en-US/chrome/venkman.dtd',
-            ],
-            [
-                'en-US',
                 'aurora',
                 'extensions/irc/chrome/chatzilla.properties:msg.save.files.folder',
                 'https://hg.mozilla.org/chatzilla/file/default/locales/en-US/chrome/chatzilla.properties',


### PR DESCRIPTION
Fix issue #708

Note that the repository has to be manually removed from /TRUNK_EN_US folder in order to clean up symlinks.