### PR TITLE
Fixes #743: Add a button to transliterate words in the main search view

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -315,7 +315,7 @@ class ShowResults
             $regular_string_id = 'string_' . $string_id;
 
             // Find if we need to transliterate the string
-            $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string != '@@missing@@';
+            $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string && $target_string != '@@missing@@';
 
             if ($transliterate) {
                 $transliterated_string = self::getTransliteratedString($target_string, 'sr-Cyrl');

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -314,7 +314,11 @@ class ShowResults
             $string_id = md5($key . mt_rand());
             $regular_string_id = 'string_' . $string_id;
 
-            // Find if we need to transliterate the string
+            /*
+                Find if we need to transliterate the string.
+                The string gets transliterated if the target local is serbian,
+                if we aren't in the 3locales view and if we have a $target_string
+            */
             $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string && $target_string != '@@missing@@';
 
             if ($transliterate) {

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -403,8 +403,8 @@ class ShowResults
                 if ($transliterate) {
                     $meta_target .= "<input type='button' value='To Latin' data-transliterated-id='{$string_id}' class='transliterate_button button action'>";
                 }
+                $meta_target .= $error_message;
             }
-            $meta_target .= "{$error_message}";
 
             // If there is no target_string2, display an error, otherwise display the string + meta links
             if ($target_string2 == '@@missing@@') {
@@ -480,9 +480,7 @@ class ShowResults
                       <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
                         &lt;report a bug&gt;
                       </a>
-                      {$meta_target}";
-            $table .= "
-                      {$error_message}
+                      {$meta_target}
                     </div>
                   </td>
                 {$extra_column_rows}

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -145,7 +145,7 @@ class ShowResults
     }
 
     /**
-     * Use the api to return a transliterated string
+     * Use the API to return a transliterated string
      *
      * @param string $string The string to be transliterated
      * @param string $locale The target locale

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -322,7 +322,7 @@ class ShowResults
             $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string && $target_string != '@@missing@@';
 
             if ($transliterate) {
-                $transliterated_string = self::getTransliteratedString($target_string, 'sr-Cyrl');
+                $transliterated_string = self::getTransliteratedString(urlencode($target_string), 'sr-Cyrl');
                 $transliterate_string_id = 'transliterate_' . $string_id;
             }
 

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -315,9 +315,7 @@ class ShowResults
             $regular_string_id = 'string_' . $string_id;
 
             // Find if we need to transliterate the string
-            $transliterate = ($locale2 == 'sr' && ! $extra_locale && $target_string)
-                ? true
-                : false;
+            $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string != '@@missing@@';
 
             if ($transliterate) {
                 $transliterated_string = self::getTransliteratedString($target_string, 'sr-Cyrl');

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -145,6 +145,21 @@ class ShowResults
     }
 
     /**
+     * Use the api to return a transliterated string
+     *
+     * @param string $string The string to be transliterated
+     * @param string $locale The target locale
+     *
+     * @return string The string transliterated into the target locale
+     */
+    public static function getTransliteratedString($string, $locale)
+    {
+        $request = new API(parse_url(API_ROOT . "transliterate/$locale/$string"));
+        $json = include MODELS . 'api/transliterate.php';
+
+        return $json[0];
+    }
+    /**
      * Return search results in a repository on strings/entities for the API
      *
      * @param  array $entities      An array of all the entities we want to return
@@ -296,21 +311,43 @@ class ShowResults
                 $target_string2 = '';
             }
 
+            $string_id = md5($target_string);
+            $regular_string_id = 'string_' . $string_id;
+
+            // Find if we need to transliterate the string
+            $transliterate = ($locale2 == 'sr' && ! $extra_locale && $target_string)
+                ? true
+                : false;
+
+            if ($transliterate) {
+                $transliterated_string = self::getTransliteratedString($target_string, 'sr-Cyrl');
+                $transliterate_string_id = 'transliterate_' . $string_id;
+            }
+
             foreach ($search as $val) {
                 $source_string = Utils::markString($val, $source_string);
                 $target_string = Utils::markString($val, $target_string);
                 if ($extra_locale) {
                     $target_string2 = Utils::markString($val, $target_string2);
                 }
+                if ($transliterate) {
+                    $transliterated_string = Utils::markString($val, $transliterated_string);
+                }
             }
 
             // Escape HTML before highlighing search terms
             $source_string = htmlspecialchars($source_string);
             $target_string = htmlspecialchars($target_string);
+
             $source_string = Utils::highlightString($source_string);
             $target_string = Utils::highlightString($target_string);
             $source_string = Strings::highlightSpecial($source_string);
             $target_string = Strings::highlightSpecial($target_string);
+
+            if ($transliterate) {
+                $transliterated_string = htmlspecialchars($transliterated_string);
+                $transliterated_string = Utils::highlightString($transliterated_string);
+            }
 
             if ($extra_locale) {
                 $target_string2 = htmlspecialchars($target_string2);
@@ -362,10 +399,12 @@ class ShowResults
             } elseif (! $target_string) {
                 $target_string = '<em class="error">Warning: Empty string</em>';
             } else {
-                $meta_target = "
-                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'></span>
-                      {$error_message}";
+                $meta_target = "<span class='clipboard' data-clipboard-target='#{$regular_string_id}' alt='Copy to clipboard'></span>";
+                if ($transliterate) {
+                    $meta_target .= "<input type='button' value='To Latin' data-transliterated-id='{$string_id}' class='transliterate_button button action'>";
+                }
             }
+            $meta_target .= "{$error_message}";
 
             // If there is no target_string2, display an error, otherwise display the string + meta links
             if ($target_string2 == '@@missing@@') {
@@ -428,7 +467,11 @@ class ShowResults
 
                   <td dir='{$direction2}' lang='{$locale2}'>
                     <span class='celltitle'>{$locale2}</span>
-                    <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
+                    <div class='string' id='{$regular_string_id}'>{$target_string}</div>";
+            if ($transliterate) {
+                $table .= "<div class='string toggle' id='{$transliterate_string_id}' style='display: none;'>{$transliterated_string}</div>";
+            }
+            $table .= "
                     <div dir='ltr' class='result_meta_link'>
                       <a class='source_link' href='{$locale2_path}'>
                         &lt;source&gt;
@@ -437,7 +480,9 @@ class ShowResults
                       <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
                         &lt;report a bug&gt;
                       </a>
-                      {$meta_target}
+                      {$meta_target}";
+            $table .= "
+                      {$error_message}
                     </div>
                   </td>
                 {$extra_column_rows}

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -311,7 +311,7 @@ class ShowResults
                 $target_string2 = '';
             }
 
-            $string_id = md5($target_string);
+            $string_id = md5($key . mt_rand());
             $regular_string_id = 'string_' . $string_id;
 
             // Find if we need to transliterate the string

--- a/app/inc/constants.php
+++ b/app/inc/constants.php
@@ -17,6 +17,7 @@ define('CONTROLLERS',   APP_ROOT . 'controllers/');
 define('CACHE_ENABLED', isset($_GET['nocache']) ? false : true);
 define('CACHE_PATH',    INSTALL_ROOT . 'cache/');
 define('APP_SCHEME',    isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https://' : 'http://');
+define('API_ROOT',  APP_SCHEME . htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES, 'UTF-8') . '/api/v1/');
 
 /*
     Determine the last Git hash from cache/version.txt, ignoring new lines.

--- a/app/inc/dispatcher.php
+++ b/app/inc/dispatcher.php
@@ -21,6 +21,7 @@ switch ($url['path']) {
         $js_files[] = '/js/component_filter.js';
         $js_files[] = '/js/main_search.js';
         $js_files[] = '/js/sorttable.js';
+        $js_files[] = '/js/toggle_transliterated_string.js';
         $js_files[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.min.js';
         break;
     case '3locales':

--- a/app/models/api/transliterate.php
+++ b/app/models/api/transliterate.php
@@ -21,4 +21,4 @@ switch ($request->parameters[2]) {
 
 $transliterator = \Transliterator::create($transliterated_locale);
 
-return [$transliterator->transliterate(Utils::secureText(urldecode($request->parameters[3])))];
+return [html_entity_decode($transliterator->transliterate(Utils::secureText(urldecode($request->parameters[3]))))];

--- a/app/models/api/transliterate.php
+++ b/app/models/api/transliterate.php
@@ -21,4 +21,4 @@ switch ($request->parameters[2]) {
 
 $transliterator = \Transliterator::create($transliterated_locale);
 
-return [$transliterator->transliterate(Utils::secureText($request->parameters[3]))];
+return [$transliterator->transliterate(Utils::secureText(urldecode($request->parameters[3])))];

--- a/web/js/toggle_transliterated_string.js
+++ b/web/js/toggle_transliterated_string.js
@@ -1,9 +1,9 @@
 $(document).ready(function() {
     $('.transliterate_button').click(function(event) {
-        var $transliterated = $('#transliterate_' + event.target.getAttribute('data-transliterated-id'));
-        var $normal = $('#string_' + event.target.getAttribute('data-transliterated-id'));
-        event.preventDefault();
         var id = event.target.getAttribute('data-transliterated-id');
+        var $transliterated = $('#transliterate_' + id);
+        var $normal = $('#string_' + id);
+        event.preventDefault();
         $normal.toggle();
         $transliterated.toggle();
         if ($normal.css('display') === 'none') {

--- a/web/js/toggle_transliterated_string.js
+++ b/web/js/toggle_transliterated_string.js
@@ -1,0 +1,17 @@
+$(document).ready(function() {
+    $('.transliterate_button').click(function(event) {
+        var $transliterated = $('#transliterate_' + event.target.getAttribute('data-transliterated-id'));
+        var $normal = $('#string_' + event.target.getAttribute('data-transliterated-id'));
+        event.preventDefault();
+        var id = event.target.getAttribute('data-transliterated-id');
+        $normal.toggle();
+        $transliterated.toggle();
+        if ($normal.css('display') === 'none') {
+            $(this).val('To Cyrillic');
+            $('span[data-clipboard-target="#string_'+id+'"]').attr('data-clipboard-target', '#transliterate_' + id);
+        } else {
+            $(this).val('To Latin');
+            $('span[data-clipboard-target="#transliterate_' + id +'"]').attr('data-clipboard-target', '#string_' + id);
+        }
+    });
+});

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -1271,13 +1271,17 @@ input[type="checkbox"]:disabled + label {
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path style="fill: rgb(0,149,221)" d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>') center no-repeat transparent;
 }
 
-
 @media only screen and (max-width: 850px) {
     .clipboard img {
         position: relative;
         right: 4px;
         bottom: 4px;
     }
+}
+
+.transliterate_button {
+    float: right;
+    cursor: pointer;
 }
 
 .tooltip {


### PR DESCRIPTION
This adds a button to toggle between Serbian Cyrillic and Serbian Latin.