### PR TITLE
Actually display abnormal string length errors

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -372,7 +372,7 @@ class ShowResults
                         $error_message = $error_message . '<em class="error"> Small string?</em>';
                         break;
                     case 'large':
-                        $error_message = $error_message . '<em class="error"> Large String?</em>';
+                        $error_message = $error_message . '<em class="error"> Large string?</em>';
                         break;
                 }
             }

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -388,7 +388,8 @@ class ShowResults
                 $error_message = '';
             }
 
-            if (! $target_string2) {
+            // Make sure not to reset $error_message when there is no extra locale
+            if ($extra_locale && ! $target_string2) {
                 $target_string2 = '<em class="error">warning: missing string</em>';
                 $error_message = '';
             }


### PR DESCRIPTION
Haven’t seen a “Large string?” error in a while? That’s because we were displaying them only on 3locales view :)