### PR TITLE
Display the same info in each mainsearch search type

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -340,6 +340,7 @@ class ShowResults
             ];
 
             $target_string = Strings::multipleStringReplace($replacements, $target_string);
+            $clipboard_target_string  = 'clip_' . md5($target_string);
 
             $temp = explode('-', $locale1);
             $locale1_short_code = $temp[0];
@@ -363,7 +364,7 @@ class ShowResults
 
             // If there is no source_string, display an error, otherwise display the string + meta links
             if (! $source_string) {
-                $source_string = '<em class="error">warning: Source string is empty</em>';
+                $source_string = '<em class="error">Warning: Source string is empty</em>';
             } else {
                 $meta_source = "
                     <div dir='ltr' class='result_meta_link'>
@@ -383,7 +384,7 @@ class ShowResults
 
             // If there is no target_string, display an error, otherwise display the string + meta links
             if (! $target_string) {
-                $target_string = '<em class="error">warning: missing string</em>';
+                $target_string = '<em class="error">Warning: Missing string</em>';
             } else {
                 $meta_target = "
                     <div dir='ltr' class='result_meta_link'>
@@ -401,7 +402,7 @@ class ShowResults
 
             // If there is no target_string2, display an error, otherwise display the string + meta links
             if (! $target_string2) {
-                $target_string2 = '<em class="error">warning: missing string</em>';
+                $target_string2 = '<em class="error">Warning: Missing string</em>';
             } else {
                 $meta_target2 = "
                     <div dir='ltr' class='result_meta_link'>
@@ -418,8 +419,6 @@ class ShowResults
 
             // Replace / and : in the key name and use it as an anchor name
             $anchor_name = str_replace(['/', ':'], '_', $key);
-
-            $clipboard_target_string  = 'clip_' . md5($target_string);
 
             // 3locales view
             if ($extra_locale) {
@@ -518,7 +517,7 @@ class ShowResults
         // Check for final dot
         if (substr(strip_tags($source_string), -1) == '.'
             && substr(strip_tags($target_string), -1) != '.') {
-            $error_message = '<em class="error"> No final dot?</em>';
+            $error_message = '<em class="error">No final dot?</em> ';
         }
 
         // Check abnormal string length
@@ -526,10 +525,10 @@ class ShowResults
         if ($length_diff) {
             switch ($length_diff) {
                 case 'small':
-                    $error_message = $error_message . '<em class="error"> Small string?</em>';
+                    $error_message = $error_message . '<em class="error">Small string?</em> ';
                     break;
                 case 'large':
-                    $error_message = $error_message . '<em class="error"> Large string?</em>';
+                    $error_message = $error_message . '<em class="error">Large string?</em> ';
                     break;
             }
         }

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -367,19 +367,14 @@ class ShowResults
                 $source_string = '<em class="error">Warning: Source string is empty</em>';
             } else {
                 $meta_source = "
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale1_path}'>
-                        &lt;source&gt;
-                      </a>
-                      <span>Translate with:</span>
-                      <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
-                      // We use html_entity_decode twice because we can have strings as &amp;amp; stored
-                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-                      . "' target='_blank'>Google</a>
-                      <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
-                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-                      . "' target='_blank'>BING</a>
-                    </div>";
+                  <span>Translate with:</span>
+                  <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
+                  // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+                  . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+                  . "' target='_blank'>Google</a>
+                  <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
+                  . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+                  . "' target='_blank'>BING</a>";
             }
 
             // If there is no target_string, display an error, otherwise display the string + meta links
@@ -387,34 +382,15 @@ class ShowResults
                 $target_string = '<em class="error">Warning: Missing string</em>';
             } else {
                 $meta_target = "
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale2_path}'>
-                        &lt;source&gt;
-                      </a>
-                      &nbsp;
-                      <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
-                        &lt;report a bug&gt;
-                      </a>
                       <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-                      {$error_message}
-                    </div>";
+                      {$error_message}";
             }
 
             // If there is no target_string2, display an error, otherwise display the string + meta links
             if (! $target_string2) {
                 $target_string2 = '<em class="error">Warning: Missing string</em>';
             } else {
-                $meta_target2 = "
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale3_path}'>
-                        &lt;source&gt;
-                      </a>
-                      &nbsp;
-                      <a class='bug_link' target='_blank' href='{$bz_link[1]}'>
-                        &lt;report a bug&gt;
-                      </a>
-                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string2}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-                    </div>";
+                $meta_target2 = "<span class='clipboard' data-clipboard-target='#{$clipboard_target_string2}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>";
             }
 
             // Replace / and : in the key name and use it as an anchor name
@@ -434,8 +410,17 @@ class ShowResults
                 <td dir='{$direction3}' lang='{$locale3}'>
                     <span class='celltitle'>{$locale3}</span>
                     <div class='string' id='{$clipboard_target_string2}'>{$target_string2}</div>
-                    {$meta_target2}
-                  </td>";
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale3_path}'>
+                        &lt;source&gt;
+                      </a>
+                      &nbsp;
+                      <a class='bug_link' target='_blank' href='{$bz_link[1]}'>
+                        &lt;report a bug&gt;
+                      </a>
+                      {$meta_target2}
+                    </div>
+                </td>";
             } else {
                 $extra_column_rows = '';
             }
@@ -452,13 +437,27 @@ class ShowResults
                     <div class='string'>
                       {$source_string}
                     </div>
-                    {$meta_source}
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale1_path}'>
+                        &lt;source&gt;
+                      </a>
+                      {$meta_source}
+                    </div>
                   </td>
 
                   <td dir='{$direction2}' lang='{$locale2}'>
                     <span class='celltitle'>{$locale2}</span>
                     <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
-                    {$meta_target}
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale2_path}'>
+                        &lt;source&gt;
+                      </a>
+                      &nbsp;
+                      <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
+                        &lt;report a bug&gt;
+                      </a>
+                      {$meta_target}
+                    </div>
                   </td>
                 {$extra_column_rows}
                 </tr>";

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -355,42 +355,65 @@ class ShowResults
                 $locale2_path = VersionControl::hgPath($locale2, $current_repo, $key);
             }
 
-            // Errors
-            $error_message = '';
+            // Get the potential errors for $target_string (final dot, long/small string)
+            $error_message = ShowResults::buildErrorString($source_string, $target_string);
 
-            // Check for final dot
-            if (substr(strip_tags($source_string), -1) == '.'
-                && substr(strip_tags($target_string), -1) != '.') {
-                $error_message = '<em class="error"> No final dot?</em>';
-            }
+            // Don't show meta links by default
+            $meta_source = $meta_target = $meta_target2 = '';
 
-            // Check abnormal string length
-            $length_diff = Utils::checkAbnormalStringLength($source_string, $target_string);
-            if ($length_diff) {
-                switch ($length_diff) {
-                    case 'small':
-                        $error_message = $error_message . '<em class="error"> Small string?</em>';
-                        break;
-                    case 'large':
-                        $error_message = $error_message . '<em class="error"> Large String?</em>';
-                        break;
-                }
-            }
-
-            // Missing string error
+            // If there is no source_string, display an error, otherwise display the string + meta links
             if (! $source_string) {
-                $source_string = '<em class="error">warning: missing string</em>';
-                $error_message = '';
+                $source_string = '<em class="error">warning: Source string is empty</em>';
+            } else {
+                $meta_source = "
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale1_path}'>
+                        &lt;source&gt;
+                      </a>
+                      <span>Translate with:</span>
+                      <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
+                      // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+                      . "' target='_blank'>Google</a>
+                      <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
+                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+                      . "' target='_blank'>BING</a>
+                    </div>";
             }
 
+            // If there is no target_string, display an error, otherwise display the string + meta links
             if (! $target_string) {
                 $target_string = '<em class="error">warning: missing string</em>';
-                $error_message = '';
+            } else {
+                $meta_target = "
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale2_path}'>
+                        &lt;source&gt;
+                      </a>
+                      &nbsp;
+                      <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
+                        &lt;report a bug&gt;
+                      </a>
+                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
+                      {$error_message}
+                    </div>";
             }
 
+            // If there is no target_string2, display an error, otherwise display the string + meta links
             if (! $target_string2) {
                 $target_string2 = '<em class="error">warning: missing string</em>';
-                $error_message = '';
+            } else {
+                $meta_target2 = "
+                    <div dir='ltr' class='result_meta_link'>
+                      <a class='source_link' href='{$locale3_path}'>
+                        &lt;source&gt;
+                      </a>
+                      &nbsp;
+                      <a class='bug_link' target='_blank' href='{$bz_link[1]}'>
+                        &lt;report a bug&gt;
+                      </a>
+                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string2}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
+                    </div>";
             }
 
             // Replace / and : in the key name and use it as an anchor name
@@ -412,16 +435,7 @@ class ShowResults
                 <td dir='{$direction3}' lang='{$locale3}'>
                     <span class='celltitle'>{$locale3}</span>
                     <div class='string' id='{$clipboard_target_string2}'>{$target_string2}</div>
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale3_path}'>
-                        &lt;source&gt;
-                      </a>
-                      &nbsp;
-                      <a class='bug_link' target='_blank' href='{$bz_link[1]}'>
-                        &lt;report a bug&gt;
-                      </a>
-                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string2}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-                    </div>
+                    {$meta_target2}
                   </td>";
             } else {
                 $extra_column_rows = '';
@@ -439,35 +453,13 @@ class ShowResults
                     <div class='string'>
                       {$source_string}
                     </div>
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale1_path}'>
-                        &lt;source&gt;
-                      </a>
-                      <span>Translate with:</span>
-                      <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
-                      // We use html_entity_decode twice because we can have strings as &amp;amp; stored
-                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-                      . "' target='_blank'>Google</a>
-                      <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
-                      . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-                      . "' target='_blank'>BING</a>
-                    </div>
+                    {$meta_source}
                   </td>
 
                   <td dir='{$direction2}' lang='{$locale2}'>
                     <span class='celltitle'>{$locale2}</span>
                     <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
-                    <div dir='ltr' class='result_meta_link'>
-                      <a class='source_link' href='{$locale2_path}'>
-                        &lt;source&gt;
-                      </a>
-                      &nbsp;
-                      <a class='bug_link' target='_blank' href='{$bz_link[0]}'>
-                        &lt;report a bug&gt;
-                      </a>
-                      <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-                      {$error_message}
-                    </div>
+                    {$meta_target}
                   </td>
                 {$extra_column_rows}
                 </tr>";
@@ -507,5 +499,46 @@ class ShowResults
         }
 
         return $entities;
+    }
+
+    /**
+     * Build the error message for target string. Can return a combination of
+     * errors, including missing final dot, long string and short string.
+     *
+     * @param string $source_string String from the source locale
+     * @param string $target_string String from the target locale
+     *
+     * @return string A concatenated string of errors or an empty string if
+     *                there is no error.
+     */
+    public static function buildErrorString($source_string, $target_string)
+    {
+        $error_message = '';
+
+        // Check for final dot
+        if (substr(strip_tags($source_string), -1) == '.'
+            && substr(strip_tags($target_string), -1) != '.') {
+            $error_message = '<em class="error"> No final dot?</em>';
+        }
+
+        // Check abnormal string length
+        $length_diff = Utils::checkAbnormalStringLength($source_string, $target_string);
+        if ($length_diff) {
+            switch ($length_diff) {
+                case 'small':
+                    $error_message = $error_message . '<em class="error"> Small string?</em>';
+                    break;
+                case 'large':
+                    $error_message = $error_message . '<em class="error"> Large string?</em>';
+                    break;
+            }
+        }
+
+        // Missing string error
+        if (! $source_string || ! $target_string) {
+            $error_message = '';
+        }
+
+        return $error_message;
     }
 }

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -53,14 +53,14 @@ if ($error_count > 0) {
                           <span class='celltitle'>{$source_locale}</span>
                           <div class='string'>" . Utils::secureText($source[$string_id]) . "</div>
                           <div class='result_meta_link'>
-                            <a class='source_link' href='{$path_locale1}'><em>&lt;source&gt;</em></a>
+                            <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
                           </div>
                        </td>
                         <td dir='{$direction2}'>
                           <span class='celltitle'>$locale</span>
                           <div class='string'>" . Utils::secureText($target[$string_id]) . "</div>
                           <div class='result_meta_link'>
-                            <a class='source_link' href='{$path_locale2}'><em>&lt;source&gt;</em></a>
+                            <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
                             <a class='bug_link' target='_blank' href='{$bugzilla_link}'>&lt;report a bug&gt;</a>
                           </div>
                        </td>

--- a/app/views/onestring.php
+++ b/app/views/onestring.php
@@ -40,7 +40,7 @@ include VIEWS . 'templates/api_promotion.php';
                  "  <td><a class='onestring_search' href='{$search_link}' title='Search for the entity in this locale'>🔍</a></td>\n";
         }
 
-             "</tr>\n";
+        "</tr>\n";
     }
     ?>
 </table>

--- a/app/views/onestring.php
+++ b/app/views/onestring.php
@@ -31,9 +31,15 @@ include VIEWS . 'templates/api_promotion.php';
         $rtl_support = RTLSupport::isRTL($locale) ? 'dir="rtl"' : '';
         $search_link = "/?sourcelocale={$reference_locale}&locale={$locale}&repo={$repo}&search_type=entities&recherche={$entity}&perfect_match=perfect_match";
         echo "<tr id='{$locale}'>\n" .
-             "  <th><a href='#{$locale}'>{$locale}</a></th>\n" .
-             "  <td lang='#{$locale}' {$rtl_support} >" . Utils::secureText($translation) . "</td>\n" .
-             "  <td><a class='onestring_search' href='{$search_link}' title='Search for the entity in this locale'>🔍</a></td>\n" .
+             "  <th><a href='#{$locale}'>{$locale}</a></th>\n";
+
+        if (! $translation) {
+            echo "  <td><em class='error'>Warning: Missing string</em></td><td></td>\n";
+        } else {
+            echo "  <td lang='#{$locale}' {$rtl_support} >" . Utils::secureText($translation) . "</td>\n" .
+                 "  <td><a class='onestring_search' href='{$search_link}' title='Search for the entity in this locale'>🔍</a></td>\n";
+        }
+
              "</tr>\n";
     }
     ?>

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -61,25 +61,19 @@ foreach ($entities as $entity) {
                                               $bz_target_string2, $current_repo, $entity_link)
                   . '">&lt;report a bug&gt;</a>';
 
-        // Don't show meta links by default
-        $meta_target2 = '';
-
-        // If there is no target_string2, display an error, otherwise display the string + meta links
+        // If there is no target_string2, display an error
         if (! $target_string2) {
             $target_string2 = '<em class="error">Warning: Missing string</em>';
-        } else {
-            $meta_target2 = "
-              <div dir='ltr' class='result_meta_link'>
-                <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
-                {$file_bug}
-              </div>";
         }
 
         $extra_column_rows = "
     <td dir='{$direction3}'>
       <span class='celltitle'>{$locale2}</span>
       <div class='string'>{$target_string2}</div>
-      {$meta_target2}
+      <div dir='ltr' class='result_meta_link'>
+        <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
+        {$file_bug}
+      </div>
     </td>";
     } else {
         $extra_column_rows = '';
@@ -117,17 +111,14 @@ foreach ($entities as $entity) {
         $source_string = '<em class="error">Warning: Source string is empty</em>';
     } else {
         $meta_source =  "
-          <div dir='ltr' class='result_meta_link'>
-            <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
-            <span>Translate with:</span>
-            <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
-            // We use html_entity_decode twice because we can have strings as &amp;amp; stored
-            . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-            . "' target='_blank'>Google</a>
-            <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
-            . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-            . "' target='_blank'>BING</a>
-          </div>";
+          <span>Translate with:</span>
+          <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
+          // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+          . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+          . "' target='_blank'>Google</a>
+          <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
+          . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+          . "' target='_blank'>BING</a>";
     }
 
     // If there is no target_string, display an error, otherwise display the string + meta links
@@ -135,11 +126,8 @@ foreach ($entities as $entity) {
         $target_string = '<em class="error">Warning: Missing string</em>';
     } else {
         $meta_target = "
-          <div dir='ltr' class='result_meta_link'>
-            <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
-            {$file_bug}{$error_message}
-            <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-          </div>";
+          {$error_message}
+          <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>";
     }
 
     $table .= "
@@ -153,12 +141,19 @@ foreach ($entities as $entity) {
     <td dir='{$direction1}'>
       <span class='celltitle'>{$source_locale}</span>
       <div class='string'>{$source_string}</div>
-      {$meta_source}
+      <div dir='ltr' class='result_meta_link'>
+        <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
+        {$meta_source}
+      </div>
     </td>
     <td dir='{$direction2}'>
       <span class='celltitle'>{$locale}</span>
       <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
-      {$meta_target}
+      <div dir='ltr' class='result_meta_link'>
+        <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
+        {$file_bug}
+        {$meta_target}
+      </div>
     </td>
     {$extra_column_rows}
   </tr>\n";

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -61,50 +61,28 @@ foreach ($entities as $entity) {
                                               $bz_target_string2, $current_repo, $entity_link)
                   . '">&lt;report a bug&gt;</a>';
 
+        // Don't show meta links by default
+        $meta_target2 = '';
+
+        // If there is no target_string2, display an error, otherwise display the string + meta links
+        if (! $target_string2) {
+            $target_string2 = '<em class="error">warning: missing string</em>';
+        } else {
+            $meta_target2 = "
+              <div dir='ltr' class='result_meta_link'>
+                <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
+                {$file_bug}
+              </div>";
+        }
+
         $extra_column_rows = "
     <td dir='{$direction3}'>
       <span class='celltitle'>{$locale2}</span>
       <div class='string'>{$target_string2}</div>
-      <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
-        {$file_bug}
-      </div>
+      {$meta_target2}
     </td>";
     } else {
         $extra_column_rows = '';
-    }
-
-    // Errors
-    $error_message = '';
-
-    // Check for final dot
-    if (substr(strip_tags($source_string), -1) == '.'
-        && substr(strip_tags($target_string), -1) != '.') {
-        $error_message = '<em class="error"> No final dot?</em>';
-    }
-
-    // Check abnormal string length
-    $length_diff = Utils::checkAbnormalStringLength($source_string, $target_string);
-    if ($length_diff) {
-        switch ($length_diff) {
-            case 'small':
-                $error_message = $error_message . '<em class="error"> Small string?</em>';
-                break;
-            case 'large':
-                $error_message = $error_message . '<em class="error"> Large String?</em>';
-                break;
-        }
-    }
-
-    // Missing string error
-    if (! $source_string) {
-        $source_string = '<em class="error">warning: missing string</em>';
-        $error_message = '';
-    }
-
-    if (! $target_string) {
-        $target_string = '<em class="error">warning: missing string</em>';
-        $error_message = '';
     }
 
     // Locale codes for machine translation services
@@ -128,6 +106,42 @@ foreach ($entities as $entity) {
 
     $clipboard_target_string  = 'clip_' . md5($target_string);
 
+    // Get the potential errors for $target_string (final dot, long/small string)
+    $error_message = ShowResults::buildErrorString($source_string, $target_string);
+
+    // Don't show meta links by default
+    $meta_source = $meta_target = '';
+
+    // If there is no source_string, display an error, otherwise display the string + meta links
+    if (! $source_string) {
+        $source_string = '<em class="error">warning: source string is empty</em>';
+    } else {
+        $meta_source =  "
+          <div dir='ltr' class='result_meta_link'>
+            <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
+            <span>Translate with:</span>
+            <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
+            // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+            . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+            . "' target='_blank'>Google</a>
+            <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
+            . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+            . "' target='_blank'>BING</a>
+          </div>";
+    }
+
+    // If there is no target_string, display an error, otherwise display the string + meta links
+    if (! $target_string) {
+        $target_string = '<em class="error">warning: missing string</em>';
+    } else {
+        $meta_target = "
+          <div dir='ltr' class='result_meta_link'>
+            <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
+            {$file_bug}{$error_message}
+            <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
+          </div>";
+    }
+
     $table .= "
   <tr>
     <td>
@@ -139,26 +153,12 @@ foreach ($entities as $entity) {
     <td dir='{$direction1}'>
       <span class='celltitle'>{$source_locale}</span>
       <div class='string'>{$source_string}</div>
-      <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
-        <span>Translate with:</span>
-        <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
-        // We use html_entity_decode twice because we can have strings as &amp;amp; stored
-        . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-        . "' target='_blank'>Google</a>
-        <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
-        . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
-        . "' target='_blank'>BING</a>
-      </div>
+      {$meta_source}
     </td>
     <td dir='{$direction2}'>
       <span class='celltitle'>{$locale}</span>
       <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
-      <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
-        {$file_bug}{$error_message}
-        <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
-      </div>
+      {$meta_target}
     </td>
     {$extra_column_rows}
   </tr>\n";

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -66,13 +66,53 @@ foreach ($entities as $entity) {
       <span class='celltitle'>{$locale2}</span>
       <div class='string'>{$target_string2}</div>
       <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale3}'><em>&lt;source&gt;</em></a>
+        <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
         {$file_bug}
       </div>
     </td>";
     } else {
         $extra_column_rows = '';
     }
+
+    // Errors
+    $error_message = '';
+
+    // Check for final dot
+    if (substr(strip_tags($source_string), -1) == '.'
+        && substr(strip_tags($target_string), -1) != '.') {
+        $error_message = '<em class="error"> No final dot?</em>';
+    }
+
+    // Check abnormal string length
+    $length_diff = Utils::checkAbnormalStringLength($source_string, $target_string);
+    if ($length_diff) {
+        switch ($length_diff) {
+            case 'small':
+                $error_message = $error_message . '<em class="error"> Small string?</em>';
+                break;
+            case 'large':
+                $error_message = $error_message . '<em class="error"> Large String?</em>';
+                break;
+        }
+    }
+
+    // Missing string error
+    if (! $source_string) {
+        $source_string = '<em class="error">warning: missing string</em>';
+        $error_message = '';
+    }
+
+    if (! $target_string) {
+        $target_string = '<em class="error">warning: missing string</em>';
+        $error_message = '';
+    }
+
+    // Locale codes for machine translation services
+    $temp = explode('-', $source_locale);
+    $locale1_short_code = $temp[0];
+
+    $temp = explode('-', $locale);
+    $locale2_short_code = $temp[0];
 
     // Link to entity
     $entity_link = "?sourcelocale={$source_locale}"
@@ -85,6 +125,9 @@ foreach ($entities as $entity) {
                                           $bz_target_string, $current_repo, $entity_link)
               . '">&lt;report a bug&gt;</a>';
     $anchor_name = str_replace(['/', ':'], '_', $entity);
+
+    $clipboard_target_string  = 'clip_' . md5($target_string);
+
     $table .= "
   <tr>
     <td>
@@ -97,15 +140,24 @@ foreach ($entities as $entity) {
       <span class='celltitle'>{$source_locale}</span>
       <div class='string'>{$source_string}</div>
       <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale1}'><em>&lt;source&gt;</em></a>
+        <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
+        <span>Translate with:</span>
+        <a href='http://translate.google.com/#{$locale1_short_code}/{$locale2_short_code}/"
+        // We use html_entity_decode twice because we can have strings as &amp;amp; stored
+        . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+        . "' target='_blank'>Google</a>
+        <a href='http://www.bing.com/translator/?from={$locale1_short_code}&to={$locale2_short_code}&text="
+        . urlencode(strip_tags(html_entity_decode(html_entity_decode($source_string))))
+        . "' target='_blank'>BING</a>
       </div>
     </td>
     <td dir='{$direction2}'>
       <span class='celltitle'>{$locale}</span>
-      <div class='string'>{$target_string}</div>
+      <div class='string' id='{$clipboard_target_string}'>{$target_string}</div>
       <div dir='ltr' class='result_meta_link'>
-        <a class='source_link' href='{$path_locale2}'><em>&lt;source&gt;</em></a>
-        {$file_bug}
+        <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
+        {$file_bug}{$error_message}
+        <span class='clipboard' data-clipboard-target='#{$clipboard_target_string}' alt='Copy to clipboard'><img src='/img/copy_icon_black_18x18.png'></span>
       </div>
     </td>
     {$extra_column_rows}

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -66,7 +66,7 @@ foreach ($entities as $entity) {
 
         // If there is no target_string2, display an error, otherwise display the string + meta links
         if (! $target_string2) {
-            $target_string2 = '<em class="error">warning: missing string</em>';
+            $target_string2 = '<em class="error">Warning: Missing string</em>';
         } else {
             $meta_target2 = "
               <div dir='ltr' class='result_meta_link'>
@@ -114,7 +114,7 @@ foreach ($entities as $entity) {
 
     // If there is no source_string, display an error, otherwise display the string + meta links
     if (! $source_string) {
-        $source_string = '<em class="error">warning: source string is empty</em>';
+        $source_string = '<em class="error">Warning: Source string is empty</em>';
     } else {
         $meta_source =  "
           <div dir='ltr' class='result_meta_link'>
@@ -132,7 +132,7 @@ foreach ($entities as $entity) {
 
     // If there is no target_string, display an error, otherwise display the string + meta links
     if (! $target_string) {
-        $target_string = '<em class="error">warning: missing string</em>';
+        $target_string = '<em class="error">Warning: Missing string</em>';
     } else {
         $meta_target = "
           <div dir='ltr' class='result_meta_link'>

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -299,4 +299,56 @@ class ShowResults extends atoum\test
             ->array($obj->getSuggestionsResults($source, $target, 'Bookmark', 3))
                 ->isEqualTo(['Bookmark', 'Nouveaux marque-pages']);
     }
+
+    public function buildErrorStringDP()
+    {
+        return [
+            [
+                'Le système de marque-pages et.',
+                'Le système de marque-pages et',
+                '<em class="error"> No final dot?</em>',
+            ],
+            [
+                'Le système de marque-pages et',
+                'Le système de marque-pages et',
+                '',
+            ],
+            [
+                'Le système de marque-pages et.',
+                'Le système de marque-pages et.',
+                '',
+            ],
+            [
+                'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
+                'Le système de marque-pages et',
+                '<em class="error"> No final dot?</em><em class="error"> Small string?</em>',
+            ],
+            [
+                'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
+                'Le système de marque-pages et.',
+                '<em class="error"> Small string?</em>',
+            ],
+            [
+                'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
+                'Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème. Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème',
+                '<em class="error"> No final dot?</em><em class="error"> Large string?</em>',
+            ],
+            [
+                'Le système de marque-pages et',
+                'Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème. Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème.',
+                '<em class="error"> Large string?</em>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider buildErrorStringDP
+     */
+    public function testBuildErrorString($a, $b, $c)
+    {
+        $obj = new _ShowResults();
+        $this
+            ->string($obj->buildErrorString($a, $b))
+                ->isEqualTo($c);
+    }
 }

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -306,7 +306,7 @@ class ShowResults extends atoum\test
             [
                 'Le système de marque-pages et.',
                 'Le système de marque-pages et',
-                '<em class="error"> No final dot?</em>',
+                '<em class="error">No final dot?</em> ',
             ],
             [
                 'Le système de marque-pages et',
@@ -321,22 +321,22 @@ class ShowResults extends atoum\test
             [
                 'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
                 'Le système de marque-pages et',
-                '<em class="error"> No final dot?</em><em class="error"> Small string?</em>',
+                '<em class="error">No final dot?</em> <em class="error">Small string?</em> ',
             ],
             [
                 'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
                 'Le système de marque-pages et.',
-                '<em class="error"> Small string?</em>',
+                '<em class="error">Small string?</em> ',
             ],
             [
                 'The bookmarks and history system will not be functional because one of files is in use by another application. Some security software can cause this problem.',
                 'Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème. Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème',
-                '<em class="error"> No final dot?</em><em class="error"> Large string?</em>',
+                '<em class="error">No final dot?</em> <em class="error">Large string?</em> ',
             ],
             [
                 'Le système de marque-pages et',
                 'Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème. Le système de marque-pages et dhistorique ne sera pas opérationnel car lun des fichiers de %S est en cours dutilisation par une autre application. Certains logiciels de sécurité peuvent causer ce problème.',
-                '<em class="error"> Large string?</em>',
+                '<em class="error">Large string?</em> ',
             ],
         ];
     }


### PR DESCRIPTION
Displaying the same info and features on string, entities and string&entities search types. Also displaying the <source> link in yellow everywhere for consistency.

This add "Translate with", the clipboard button and abnormal string length errors to the entity search. (Follow up to issue #760)