### PR TITLE
Update release notes layout for multiline items

### DIFF
--- a/app/views/changelog.php
+++ b/app/views/changelog.php
@@ -20,11 +20,12 @@ foreach ($changelog as $release => $changes) {
 
         $output .= "  <li>";
         $output .= isset($attributes['type']) ? $relnotes($attributes['type'][0]) . ' ' : '';
+        $output .= '<div>';
         $output .= isset($attributes['issues']) ? $issue($attributes['issues']) : '';
         $output .= isset($attributes['commit']) ? $commit($attributes['commit']) : '';
         $output .= $attributes['message'][0];
         $output .= isset($attributes['authors']) ? $authors($attributes['authors']) : '';
-        $output .= "</li>\n";
+        $output .= "</div></li>\n";
     }
     $output .= "</ul>\n";
     $output .= $github_link($release);

--- a/web/style/changelog.css
+++ b/web/style/changelog.css
@@ -13,6 +13,15 @@
     width: 100%;
 }
 
+#changelog #pagecontent ul li {
+    display: table;
+}
+
+#changelog #pagecontent ul li div,
+.release_tag {
+    display: table-cell;
+}
+
 #changelog h3 {
     margin: 0;
     width: 100%;


### PR DESCRIPTION
Prevents the text from wrapping under the .release_tag element, I find it easier to read