### PR TITLE
Fix missing background on horizontal scroll

### DIFF
--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -62,6 +62,7 @@
 
 html {
     min-height: 100%;
+    background-color: #cce0f0;
 }
 
 body {
@@ -79,7 +80,6 @@ body {
 }
 
 #main-wrapper {
-    background-color: #cce0f0;
     border-top: 2px solid #fff;
     padding-bottom: 0.5em;
     flex: 1;
@@ -451,6 +451,7 @@ td .result_meta_link .bug_link {
     font-size: 0.9em;
     padding: 1em;
     line-height: 0.4;
+    background-color: #fff;
 }
 
 /* colors for results */


### PR DESCRIPTION
This fixes the missing background here https://transvision-beta.mozfr.org/3locales/?recherche=test&repo=aurora&sourcelocale=en-US&locale=fr&locale2=fr&search_type=strings

I tried to style the table differently to get rid of the overflow, had good results with  table-layout: fixed; and break-words, but not good enough and that seem a bad idea to touch that today.