### PR TITLE
Stop changing whitespaces in searched strings

### DIFF
--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -132,7 +132,7 @@ class Search
      */
     public function setSearchTerms($string)
     {
-        $this->search_terms = trim($string);
+        $this->search_terms = $string;
         $this->regex_search_terms = $this->search_terms;
         $this->updateRegex();
 

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -173,7 +173,7 @@ class ShowResults
         $output = [];
 
         $clean_string = function ($string) {
-            return trim(htmlspecialchars_decode($string, ENT_QUOTES));
+            return htmlspecialchars_decode($string, ENT_QUOTES);
         };
 
         foreach ($search_results as $entity => $set) {
@@ -289,8 +289,8 @@ class ShowResults
 
             $component = explode('/', $key)[0];
             $fileAndRawString = explode(':', $key);
-            $source_string = trim($strings[0]);
-            $target_string = trim($strings[1]);
+            $source_string = $strings[0];
+            $target_string = $strings[1];
 
             $entity_link = "?sourcelocale={$locale1}"
             . "&locale={$locale2}"
@@ -303,7 +303,7 @@ class ShowResults
             )];
 
             if ($extra_locale) {
-                $target_string2 = trim($strings[2]);
+                $target_string2 = $strings[2];
                 $entity_link = "?sourcelocale={$locale1}"
                                 . "&locale={$search_object->getLocale('extra')}"
                                 . "&repo={$current_repo}"

--- a/app/classes/Transvision/Strings.php
+++ b/app/classes/Transvision/Strings.php
@@ -11,18 +11,16 @@ namespace Transvision;
 class Strings
 {
     /**
-     * Replace contiguous spaces in a string by a single space
+     * Replace contiguous spaces in a string by a single space.
+     * Leading and trailing spaces are preserved but collapsed
+     * to a single space.
      *
      * @param  string $string The string to analyze
      * @return string Cleaned up string with extra spaces merged
      */
     public static function mtrim($string)
     {
-        $string = explode(' ', $string);
-        $string = array_filter($string);
-        $string = implode(' ', $string);
-
-        return $string;
+        return preg_replace('/\s+/', ' ', $string);
     }
 
     /**

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -233,9 +233,6 @@ class Utils
             return '';
         }
 
-        // Filter out double spaces
-        $string = Strings::mtrim($string);
-
         return $string;
     }
 

--- a/app/models/api/entity.php
+++ b/app/models/api/entity.php
@@ -12,9 +12,9 @@ if (! $translations = Cache::getKey($cache_id)) {
         $strings = Utils::getRepoStrings($locale_code, $repo);
 
         if (isset($strings[$entity])) {
-            $strings[$entity] = trim($strings[$entity]);
+            $strings[$entity] = $strings[$entity];
             if (Strings::endsWith(strtolower($strings[$entity]), '{ok}')) {
-                $strings[$entity] = trim(substr($strings[$entity], 0, -4));
+                $strings[$entity] = substr($strings[$entity], 0, -4);
             }
             $translations[$locale_code] = $strings[$entity];
         }

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -60,10 +60,10 @@ class Search extends atoum\test
         $obj->setSearchTerms(' foobar ');
         $this
             ->string($obj->getSearchTerms())
-                ->isEqualTo('foobar');
+                ->isEqualTo(' foobar ');
         $this
             ->string($obj->getRegexSearchTerms())
-                ->isEqualTo('foobar');
+                ->isEqualTo(' foobar ');
     }
 
     public function testSetRegexSearchTerms()

--- a/tests/units/Transvision/Strings.php
+++ b/tests/units/Transvision/Strings.php
@@ -10,18 +10,23 @@ class Strings extends atoum\test
 {
     public function mtrimDP()
     {
-        return ['Le cheval  blanc '];
+        return [
+            ['Le cheval  blanc ', 'Le cheval blanc '],
+            ['  Le cheval  blanc', ' Le cheval blanc'],
+            ['  Le cheval  blanc  ', ' Le cheval blanc '],
+            ['Le cheval  blanc', 'Le cheval blanc'],
+        ];
     }
 
     /**
      * @dataProvider mtrimDP
      */
-    public function testMtrim($a)
+    public function testMtrim($a, $b)
     {
         $obj = new _Strings();
         $this
             ->string($obj->mtrim($a))
-                ->isEqualTo('Le cheval blanc');
+                ->isEqualTo($b);
     }
 
     public function startsWithDP()

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -178,12 +178,8 @@ class Utils extends atoum\test
     {
         return [
             [
-                'pages web   fréquemment visitées (en cliquant sur « Recharger »,',
-                'pages web fréquemment visitées (en cliquant sur « Recharger »,',
-            ],
-            [
-                'toto ',
-                'toto',
+                [],
+                '',
             ],
             [
                 "don\u0027t strip unicode escaped chars",

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -512,6 +512,7 @@ table tr td.no_highligth {
     color: #000;
     background-color: rgba(255, 165, 0, 0.77);
     border-radius: 3px;
+    white-space: pre-wrap;
 }
 
 .superset {


### PR DESCRIPTION
The idea is that we change the searched string a log, by dropping trailing/leading whitespaces, and collapsing multiple spaces. I don't think it makes a lot of sense.

You can get an idea by looking at this page and searching some of HTML strings
https://transvision.mozfr.org/consistency/?locale=eu&repo=aurora&filter=all

Note: the string appear on multiple lines because the `highlight` class is acting as `<pre>` now, so it's expected.

I've updated the mtrim function, but it's currently unused. Not sure if we want to get rid of it completely.

I've been testing this for a bit, and couldn't find any evident issue. This also fixes #824 