### PR TITLE
Rework advanced search options, and default search behavior

### DIFF
--- a/app/classes/Transvision/API.php
+++ b/app/classes/Transvision/API.php
@@ -15,7 +15,7 @@ use Monolog\Logger;
  * Calls are like this:
  * api/<version>/<service>/<repository>/<search type>/<source locale>/<target locale>/<url escaped search>/?optional_parameter1=foo&optional_parameter2=bar
  * Example for an entity search containing bookmark:
- * https://transvision.mozfr.org/api/v1/tm/release/entity/en-US/fr/bookmark/?case_sensitive=1
+ * https://transvision.mozfr.org/api/v1/tm/release/entity/en-US/fr/bookmark/?case_sensitive=case_sensitive
  * (tm = translation memory service)
  *
  * Example for the list of locales supported for a repo:
@@ -245,7 +245,7 @@ class API
 
                 break;
             case 'search':
-            // ex: /api/v1/search/string/central/en-US/fr/Bookmark/?case_sensitive=1
+            // ex: /api/v1/search/string/central/en-US/fr/Bookmark/?case_sensitive=case_sensitive
                 if (! $this->verifyEnoughParameters(7)) {
                     return false;
                 }

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -45,7 +45,7 @@ class Search
     protected $regex_entire_string;
 
     /**
-     * Only return strings that where entire words match the search (case excluded)
+     * Only return strings where entire words match the search (case excluded)
      * @var boolean
      */
     protected $regex_entire_words;
@@ -170,7 +170,7 @@ class Search
     }
 
     /**
-     * Set the regex to only return strings that entirely matches the
+     * Set the regex to only return strings that entirely match the
      * searched string.
      * We cast the value to a boolean because we usually get it from a GET.
      *
@@ -186,7 +186,7 @@ class Search
     }
 
     /**
-     * Set the regex to only return strings where entire words matches
+     * Set the regex to only return strings where entire words match
      * the searched string.
      * We cast the value to a boolean because we usually get it from a GET.
      *

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -13,6 +13,7 @@ namespace Transvision;
  *     ->setRegexCaseInsensitive(true)
  *     ->setRegexEntireString(false)
  *     ->setEachWord(false)
+ *     ->setEntireWords(false)
  *     ->setRepository('release')
  *     ->setSearchType('strings')
  *     ->setLocales(['en-US', 'fr']);
@@ -42,6 +43,12 @@ class Search
      * @var boolean
      */
     protected $regex_entire_string;
+
+    /**
+     * Only return strings that where entire words match the search (case excluded)
+     * @var boolean
+     */
+    protected $regex_entire_words;
 
     /**
      * Set to search for each word in the query instead of using it as a whole.
@@ -80,7 +87,7 @@ class Search
      */
     protected $form_search_options = [
         'case_sensitive', 'entire_string', 'repo',
-        'search_type', 't2t', 'each_word',
+        'search_type', 't2t', 'each_word', 'entire_words',
     ];
 
     /**
@@ -104,6 +111,7 @@ class Search
         $this->regex = '';
         $this->regex_case = 'i';
         $this->regex_entire_string = false;
+        $this->regex_entire_words = false;
         $this->each_word = false;
         $this->regex_search_terms = '';
         $this->repository = 'aurora'; // Most locales work on Aurora
@@ -162,7 +170,8 @@ class Search
     }
 
     /**
-     * Set the regex to only return string that entirely matches the searched string.
+     * Set the regex to only return strings that entirely matches the
+     * searched string.
      * We cast the value to a boolean because we usually get it from a GET.
      *
      * @param  boolean $flag Set to True for an entire string match
@@ -171,6 +180,22 @@ class Search
     public function setRegexEntireString($flag)
     {
         $this->regex_entire_string = (boolean) $flag;
+        $this->updateRegex();
+
+        return $this;
+    }
+
+    /**
+     * Set the regex to only return strings where entire words matches
+     * the searched string.
+     * We cast the value to a boolean because we usually get it from a GET.
+     *
+     * @param  boolean $flag Set to True for an entire words match
+     * @return $this
+     */
+    public function setRegexEntireWords($flag)
+    {
+        $this->regex_entire_words = (boolean) $flag ? '\b' : '';
         $this->updateRegex();
 
         return $this;
@@ -205,7 +230,9 @@ class Search
 
         $this->regex =
             '~'
+            . $this->regex_entire_words
             . $search
+            . $this->regex_entire_words
             . '~'
             . $this->regex_case
             . 'u';
@@ -244,6 +271,26 @@ class Search
     }
 
     /**
+     * Get the state of entire_words
+     *
+     * @return boolean True if the search should be only for entire word.
+     */
+    public function isEntireWords()
+    {
+        return $this->regex_entire_words == '\b' ? true : false;
+    }
+
+    /**
+     * Get the state of case_sensitive
+     *
+     * @return boolean False if the search should be case sensitive
+     */
+    public function isCaseSensitive()
+    {
+        return $this->regex_case == 'i' ? false : true;
+    }
+
+    /**
      * Get search terms
      *
      * @return string Searched terms
@@ -261,16 +308,6 @@ class Search
     public function getRegexSearchTerms()
     {
         return $this->regex_search_terms;
-    }
-
-    /**
-     * Get the regex case
-     *
-     * @return string Return 'i' for case insensitive search, '' for sensitive
-     */
-    public function getRegexCase()
-    {
-        return $this->regex_case;
     }
 
     /**

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -10,9 +10,9 @@ namespace Transvision;
  * e.g.:
  * $search = (new Search)
  *     ->setSearchTerms('Bookmark this page')
- *     ->setRegexWholeWords(true)
  *     ->setRegexCaseInsensitive(true)
  *     ->setRegexPerfectMatch(false)
+ *     ->setDistinctWords(false)
  *     ->setRepository('release')
  *     ->setSearchType('strings')
  *     ->setLocales(['en-US', 'fr']);
@@ -38,16 +38,16 @@ class Search
     protected $regex_case;
 
     /**
-     * Consider the space separated string as a single word for search
-     * @var string
-     */
-    protected $regex_whole_words;
-
-    /**
      * Only return strings that match the search perfectly (case excluded)
      * @var boolean
      */
     protected $regex_perfect_match;
+
+    /**
+     * Search for each distinct word
+     * @var boolean
+     */
+    protected $distinct_words;
 
     /**
      * The search terms for the regex, these differ from $search_terms as
@@ -79,7 +79,8 @@ class Search
      * @var array
      */
     protected $form_search_options = [
-        'case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'whole_word',
+        'case_sensitive', 'perfect_match', 'repo',
+        'search_type', 't2t', 'distinct_words',
     ];
 
     /**
@@ -102,8 +103,8 @@ class Search
         $this->search_terms = '';
         $this->regex = '';
         $this->regex_case = 'i';
-        $this->regex_whole_words = '';
         $this->regex_perfect_match = false;
+        $this->distinct_words = false;
         $this->regex_search_terms = '';
         $this->repository = 'aurora'; // Most locales work on Aurora
         $this->search_type = 'strings';
@@ -176,16 +177,15 @@ class Search
     }
 
     /**
-     * Set the regex so as that a multi-word search is taken as a single word.
+     * Set to search for each distinct word.
      * We cast the value to a boolean because we usually get it from a GET.
      *
-     * @param  boolean $flag A string evaluated to True will add \b to the regex
+     * @param  boolean $flag Set to True for a perfect match
      * @return $this
      */
-    public function setRegexWholeWords($flag)
+    public function setDistinctWords($flag)
     {
-        $this->regex_whole_words = (boolean) $flag ? '\b' : '';
-        $this->updateRegex();
+        $this->distinct_words = (boolean) $flag;
 
         return $this;
     }
@@ -205,9 +205,7 @@ class Search
 
         $this->regex =
             '~'
-            . $this->regex_whole_words
             . $search
-            . $this->regex_whole_words
             . '~'
             . $this->regex_case
             . 'u';
@@ -233,6 +231,16 @@ class Search
     public function isPerfectMatch()
     {
         return $this->regex_perfect_match;
+    }
+
+    /**
+     * Get the state of distinct
+     *
+     * @return boolean True if the regex searches for a perfect string match
+     */
+    public function isDistinctWords()
+    {
+        return $this->distinct_words;
     }
 
     /**
@@ -263,16 +271,6 @@ class Search
     public function getRegexCase()
     {
         return $this->regex_case;
-    }
-
-    /**
-     * Get the regex whole words
-     *
-     * @return boolean True if we have the 'whole words' option for the regex
-     */
-    public function isWholeWords()
-    {
-        return $this->regex_whole_words;
     }
 
     /**

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -12,7 +12,7 @@ namespace Transvision;
  *     ->setSearchTerms('Bookmark this page')
  *     ->setRegexCaseInsensitive(true)
  *     ->setRegexEntireString(false)
- *     ->setDistinctWords(false)
+ *     ->setEachWord(false)
  *     ->setRepository('release')
  *     ->setSearchType('strings')
  *     ->setLocales(['en-US', 'fr']);
@@ -47,7 +47,7 @@ class Search
      * Set to search for each word in the query instead of using it as a whole.
      * @var boolean
      */
-    protected $distinct_words;
+    protected $each_word;
 
     /**
      * The search terms for the regex, these differ from $search_terms as
@@ -80,7 +80,7 @@ class Search
      */
     protected $form_search_options = [
         'case_sensitive', 'entire_string', 'repo',
-        'search_type', 't2t', 'distinct_words',
+        'search_type', 't2t', 'each_word',
     ];
 
     /**
@@ -104,7 +104,7 @@ class Search
         $this->regex = '';
         $this->regex_case = 'i';
         $this->regex_entire_string = false;
-        $this->distinct_words = false;
+        $this->each_word = false;
         $this->regex_search_terms = '';
         $this->repository = 'aurora'; // Most locales work on Aurora
         $this->search_type = 'strings';
@@ -183,9 +183,9 @@ class Search
      * @param  boolean $flag Set to True to search for each word.
      * @return $this
      */
-    public function setDistinctWords($flag)
+    public function setEachWord($flag)
     {
-        $this->distinct_words = (boolean) $flag;
+        $this->each_word = (boolean) $flag;
 
         return $this;
     }
@@ -234,13 +234,13 @@ class Search
     }
 
     /**
-     * Get the state of distinct_words
+     * Get the state of each_word
      *
      * @return boolean True if the search should be for each word.
      */
-    public function isDistinctWords()
+    public function isEachWord()
     {
-        return $this->distinct_words;
+        return $this->each_word;
     }
 
     /**

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -44,7 +44,7 @@ class Search
     protected $regex_perfect_match;
 
     /**
-     * Search for each distinct word
+     * Set to search for each word in the query instead of using it as a whole.
      * @var boolean
      */
     protected $distinct_words;
@@ -177,10 +177,10 @@ class Search
     }
 
     /**
-     * Set to search for each distinct word.
+     * Set to search for each word in the query instead of using it as a whole.
      * We cast the value to a boolean because we usually get it from a GET.
      *
-     * @param  boolean $flag Set to True for a perfect match
+     * @param  boolean $flag Set to True to search for each word.
      * @return $this
      */
     public function setDistinctWords($flag)
@@ -234,9 +234,9 @@ class Search
     }
 
     /**
-     * Get the state of distinct
+     * Get the state of distinct_words
      *
-     * @return boolean True if the regex searches for a perfect string match
+     * @return boolean True if the search should be for each word.
      */
     public function isDistinctWords()
     {

--- a/app/classes/Transvision/Search.php
+++ b/app/classes/Transvision/Search.php
@@ -11,7 +11,7 @@ namespace Transvision;
  * $search = (new Search)
  *     ->setSearchTerms('Bookmark this page')
  *     ->setRegexCaseInsensitive(true)
- *     ->setRegexPerfectMatch(false)
+ *     ->setRegexEntireString(false)
  *     ->setDistinctWords(false)
  *     ->setRepository('release')
  *     ->setSearchType('strings')
@@ -38,10 +38,10 @@ class Search
     protected $regex_case;
 
     /**
-     * Only return strings that match the search perfectly (case excluded)
+     * Only return strings that entirely match the search (case excluded)
      * @var boolean
      */
-    protected $regex_perfect_match;
+    protected $regex_entire_string;
 
     /**
      * Set to search for each word in the query instead of using it as a whole.
@@ -79,7 +79,7 @@ class Search
      * @var array
      */
     protected $form_search_options = [
-        'case_sensitive', 'perfect_match', 'repo',
+        'case_sensitive', 'entire_string', 'repo',
         'search_type', 't2t', 'distinct_words',
     ];
 
@@ -103,7 +103,7 @@ class Search
         $this->search_terms = '';
         $this->regex = '';
         $this->regex_case = 'i';
-        $this->regex_perfect_match = false;
+        $this->regex_entire_string = false;
         $this->distinct_words = false;
         $this->regex_search_terms = '';
         $this->repository = 'aurora'; // Most locales work on Aurora
@@ -162,15 +162,15 @@ class Search
     }
 
     /**
-     * Set the regex to only return perfect matches for the searched string.
+     * Set the regex to only return string that entirely matches the searched string.
      * We cast the value to a boolean because we usually get it from a GET.
      *
-     * @param  boolean $flag Set to True for a perfect match
+     * @param  boolean $flag Set to True for an entire string match
      * @return $this
      */
-    public function setRegexPerfectMatch($flag)
+    public function setRegexEntireString($flag)
     {
-        $this->regex_perfect_match = (boolean) $flag;
+        $this->regex_entire_string = (boolean) $flag;
         $this->updateRegex();
 
         return $this;
@@ -199,7 +199,7 @@ class Search
     private function updateRegex()
     {
         $search = preg_quote($this->regex_search_terms);
-        if ($this->regex_perfect_match) {
+        if ($this->regex_entire_string) {
             $search = "^{$search}$";
         }
 
@@ -224,13 +224,13 @@ class Search
     }
 
     /**
-     * Get the state of regex_perfect_match
+     * Get the state of regex_entire_string
      *
-     * @return boolean True if the regex searches for a perfect string match
+     * @return boolean True if the regex searches for an entire string match
      */
-    public function isPerfectMatch()
+    public function isEntireString()
     {
-        return $this->regex_perfect_match;
+        return $this->regex_entire_string;
     }
 
     /**

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -292,7 +292,7 @@ class ShowResults
             . "&locale={$locale2}"
             . "&repo={$current_repo}"
             . "&search_type=entities&recherche={$key}"
-            . "&perfect_match=perfect_match";
+            . "&entire_string=entire_string";
 
             $bz_link = [Bugzilla::reportErrorLink(
                 $locale2, $key, $source_string, $target_string, $current_repo, $entity_link
@@ -304,7 +304,7 @@ class ShowResults
                                 . "&locale={$search_object->getLocale('extra')}"
                                 . "&repo={$current_repo}"
                                 . "&search_type=entities&recherche={$key}"
-                                . "&perfect_match=perfect_match";
+                                . "&entire_string=entire_string";
                 $bz_link[] = Bugzilla::reportErrorLink(
                     $search_object->getLocale('extra'), $key, $source_string, $target_string2, $current_repo, $entity_link
                 );
@@ -512,7 +512,7 @@ class ShowResults
 
         /*
             If there are no results, search also through the entity names.
-            This is needed for "perfect match" when only the entity name is
+            This is needed for "entire string" when only the entity name is
             provided.
         */
         if (empty($entities)) {

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -267,10 +267,10 @@ class ShowResults
                      </thead>
                      <tbody>\n";
 
-        if (! $search_object->isWholeWords() && ! $search_object->isPerfectMatch()) {
-            $search = Utils::uniqueWords($search_object->getSearchTerms());
+        if ($search_object->isDistinctWords()) {
+            $search_terms = Utils::uniqueWords($search_object->getSearchTerms());
         } else {
-            $search = [$search_object->getSearchTerms()];
+            $search_terms = [$search_object->getSearchTerms()];
         }
 
         $current_repo = $search_object->getRepository();
@@ -281,7 +281,7 @@ class ShowResults
             if ($search_object->getSearchType() == 'strings') {
                 $result_entity = self::formatEntity($key);
             } else {
-                $result_entity = self::formatEntity($key, $search[0]);
+                $result_entity = self::formatEntity($key, $search_terms[0]);
             }
 
             $component = explode('/', $key)[0];
@@ -327,14 +327,14 @@ class ShowResults
                 $transliterate_string_id = 'transliterate_' . $string_id;
             }
 
-            foreach ($search as $val) {
-                $source_string = Strings::markString($val, $source_string);
-                $target_string = Strings::markString($val, $target_string);
+            foreach ($search_terms as $search_term) {
+                $source_string = Strings::markString($search_term, $source_string);
+                $target_string = Strings::markString($search_term, $target_string);
                 if ($extra_locale) {
-                    $target_string2 = Strings::markString($val, $target_string2);
+                    $target_string2 = Strings::markString($search_term, $target_string2);
                 }
                 if ($transliterate) {
-                    $transliterated_string = Strings::markString($val, $transliterated_string);
+                    $transliterated_string = Strings::markString($search_term, $transliterated_string);
                 }
             }
 

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -267,7 +267,7 @@ class ShowResults
                      </thead>
                      <tbody>\n";
 
-        if ($search_object->isDistinctWords()) {
+        if ($search_object->isEachWord()) {
             $search_terms = Utils::uniqueWords($search_object->getSearchTerms());
         } else {
             $search_terms = [$search_object->getSearchTerms()];

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -124,7 +124,8 @@ class Utils
     }
 
     /**
-     * Split a sentence in words from longest to shortest
+     * Split a sentence in words from longest to shortest, ignoring
+     * words shorter than 2 characters.
      *
      * @param  string $sentence
      * @return array  all the words in the sentence sorted by length
@@ -133,7 +134,14 @@ class Utils
     {
         $words = explode(' ', $sentence);
         $words = array_filter($words); // Filter out extra spaces
-        $words = array_unique($words); // Remove duplicate words
+        // Filter out 1-character words
+        $words = array_filter($words, function($a) {
+            return (mb_strlen($a) >= 2);
+        });
+
+        // Remove duplicate words
+        $words = array_unique($words);
+
         // Sort words from longest to shortest
         usort(
             $words,

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -135,7 +135,7 @@ class Utils
         $words = explode(' ', $sentence);
         $words = array_filter($words); // Filter out extra spaces
         // Filter out 1-character words
-        $words = array_filter($words, function($a) {
+        $words = array_filter($words, function ($a) {
             return (mb_strlen($a) >= 2);
         });
 

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -444,8 +444,8 @@ class Utils
             array_map($sanitize, array_values($args))
         );
 
-        $args['locale'] = $source_locale;
-        $args['sourcelocale'] = $target_locale;
+        $args['locale'] = $target_locale;
+        $args['sourcelocale'] = $source_locale;
         $args['json'] = 'true';
 
         // We don't want to encode slashes in searches for entity names

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -32,8 +32,8 @@ if (isset($_GET['json'])) {
 
     $regex = [];
     $regex['distinct_words'] = isset($_GET['distinct_words']) ? 'distinct_words=distinct_words' : '';
-    $regex['case'] = isset($_GET['case_sensitive']) ? 'case_sensitive=case_sensitive' : '';
-    $regex['perfect'] = isset($_GET['perfect_match']) ? 'perfect_match=perfect_match' : '';
+    $regex['case_sensitive'] = isset($_GET['case_sensitive']) ? 'case_sensitive=case_sensitive' : '';
+    $regex['entire_string'] = isset($_GET['entire_string']) ? 'entire_string=entire_string' : '';
     $regex = array_filter($regex);
     $regex = count($regex) > 0 ? '?' . implode('&', $regex) : '';
 

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -31,9 +31,9 @@ if (isset($_GET['json'])) {
         : '';
 
     $regex = [];
-    $regex['distinct_words'] = isset($_GET['distinct_words']) ? 'distinct_words=1' : '';
-    $regex['case'] = isset($_GET['case_sensitive']) ? 'case_sensitive=1' : '';
-    $regex['perfect'] = isset($_GET['perfect_match']) ? 'perfect_match=1' : '';
+    $regex['distinct_words'] = isset($_GET['distinct_words']) ? 'distinct_words=distinct_words' : '';
+    $regex['case'] = isset($_GET['case_sensitive']) ? 'case_sensitive=case_sensitive' : '';
+    $regex['perfect'] = isset($_GET['perfect_match']) ? 'perfect_match=perfect_match' : '';
     $regex = array_filter($regex);
     $regex = count($regex) > 0 ? '?' . implode('&', $regex) : '';
 

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -31,7 +31,7 @@ if (isset($_GET['json'])) {
         : '';
 
     $regex = [];
-    $regex['whole'] = isset($_GET['whole_word']) ? 'whole_word=1' : '';
+    $regex['distinct_words'] = isset($_GET['distinct_words']) ? 'distinct_words=1' : '';
     $regex['case'] = isset($_GET['case_sensitive']) ? 'case_sensitive=1' : '';
     $regex['perfect'] = isset($_GET['perfect_match']) ? 'perfect_match=1' : '';
     $regex = array_filter($regex);

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -31,7 +31,7 @@ if (isset($_GET['json'])) {
         : '';
 
     $regex = [];
-    $regex['distinct_words'] = isset($_GET['distinct_words']) ? 'distinct_words=distinct_words' : '';
+    $regex['each_word'] = isset($_GET['each_word']) ? 'each_word=each_word' : '';
     $regex['case_sensitive'] = isset($_GET['case_sensitive']) ? 'case_sensitive=case_sensitive' : '';
     $regex['entire_string'] = isset($_GET['entire_string']) ? 'entire_string=entire_string' : '';
     $regex = array_filter($regex);

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -34,6 +34,7 @@ if (isset($_GET['json'])) {
     $regex['each_word'] = isset($_GET['each_word']) ? 'each_word=each_word' : '';
     $regex['case_sensitive'] = isset($_GET['case_sensitive']) ? 'case_sensitive=case_sensitive' : '';
     $regex['entire_string'] = isset($_GET['entire_string']) ? 'entire_string=entire_string' : '';
+    $regex['entire_words'] = isset($_GET['entire_words']) ? 'entire_words=entire_words' : '';
     $regex = array_filter($regex);
     $regex = count($regex) > 0 ? '?' . implode('&', $regex) : '';
 

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -28,7 +28,7 @@ if (isset($_GET['search_type'])) {
 // Define our regex and search parameters
 $search
     ->setSearchTerms($my_search)
-    ->setDistinctWords($check['distinct_words'])
+    ->setEachWord($check['each_word'])
     ->setRegexCaseInsensitive($check['case_sensitive'])
     ->setRegexEntireString($check['entire_string'])
     ->setRepository($repo)

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -31,6 +31,7 @@ $search
     ->setEachWord($check['each_word'])
     ->setRegexCaseInsensitive($check['case_sensitive'])
     ->setRegexEntireString($check['entire_string'])
+    ->setRegexEntireWords($check['entire_words'])
     ->setRepository($repo)
     ->setSearchType($search_type)
     ->setLocales([$source_locale, $locale, $locale2]);

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -28,7 +28,7 @@ if (isset($_GET['search_type'])) {
 // Define our regex and search parameters
 $search
     ->setSearchTerms($my_search)
-    ->setRegexWholeWords($check['whole_word'])
+    ->setDistinctWords($check['distinct_words'])
     ->setRegexCaseInsensitive($check['case_sensitive'])
     ->setRegexPerfectMatch($check['perfect_match'])
     ->setRepository($repo)

--- a/app/inc/search_options.php
+++ b/app/inc/search_options.php
@@ -30,7 +30,7 @@ $search
     ->setSearchTerms($my_search)
     ->setDistinctWords($check['distinct_words'])
     ->setRegexCaseInsensitive($check['case_sensitive'])
-    ->setRegexPerfectMatch($check['perfect_match'])
+    ->setRegexEntireString($check['entire_string'])
     ->setRepository($repo)
     ->setSearchType($search_type)
     ->setLocales([$source_locale, $locale, $locale2]);

--- a/app/models/3locales_search.php
+++ b/app/models/3locales_search.php
@@ -7,7 +7,12 @@ if ($search->isPerfectMatch()) {
     $locale3_strings = $search->grep($tmx_target2);
 } else {
     $locale3_strings = $tmx_target2;
-    foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
+
+    $search_terms = $search->isDistinctWords()
+        ? Utils::uniqueWords($search->getSearchTerms())
+        : [$search->getSearchTerms()];
+
+    foreach ($search_terms as $word) {
         $search->setRegexSearchTerms($word);
         $locale3_strings = $search->grep($locale3_strings);
     }

--- a/app/models/3locales_search.php
+++ b/app/models/3locales_search.php
@@ -8,7 +8,7 @@ if ($search->isEntireString()) {
 } else {
     $locale3_strings = $tmx_target2;
 
-    $search_terms = $search->isDistinctWords()
+    $search_terms = $search->isEachWord()
         ? Utils::uniqueWords($search->getSearchTerms())
         : [$search->getSearchTerms()];
 

--- a/app/models/3locales_search.php
+++ b/app/models/3locales_search.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 $tmx_target2 = Utils::getRepoStrings($locale2, $search->getRepository());
 
-if ($search->isPerfectMatch()) {
+if ($search->isEntireString()) {
     $locale3_strings = $search->grep($tmx_target2);
 } else {
     $locale3_strings = $tmx_target2;

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -15,13 +15,13 @@ $repositories = $request->parameters[3] == 'global'
     : [$request->parameters[3]];
 
 $entities_merged = [];
-$source_strings_merged = [];
-$target_strings_merged = [];
+$source_results_merged = [];
+$target_results_merged = [];
 
 // Define our search terms and parameters
 $search
     ->setSearchTerms(urldecode(Utils::cleanString($request->parameters[6])))
-    ->setRegexWholeWords($get_option('whole_word'))
+    ->setDistinctWords($get_option('distinct_words'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexPerfectMatch($get_option('perfect_match'))
     ->setSearchType($request->parameters[2])
@@ -30,48 +30,56 @@ $search
 // We loop through all repositories searched and merge results
 foreach ($repositories as $repository) {
     $source_strings = Utils::getRepoStrings($search->getLocale('source'), $repository);
+    $entities = [];
+    $source_results = [];
 
     if ($search->isPerfectMatch()) {
         if ($search->getSearchType() == 'entities') {
             $entities = ShowResults::searchEntities($source_strings, $search->getRegex());
-            $source_strings = array_intersect_key($source_strings, array_flip($entities));
+            $source_results = array_intersect_key($source_strings, array_flip($entities));
         } else {
-            $source_strings = $search->grep($source_strings);
-            $entities = array_keys($source_strings);
+            $source_results = $search->grep($source_strings);
+            $entities = array_keys($source_results);
         }
     } else {
-        foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
+        $search_terms = $search->isDistinctWords()
+            ? Utils::uniqueWords($search->getSearchTerms())
+            : [$search->getSearchTerms()];
+
+        foreach ($search_terms as $word) {
             $search->setRegexSearchTerms($word);
             if ($search->getSearchType() == 'entities') {
-                $entities = ShowResults::searchEntities($source_strings, $search->getRegex());
-                $source_strings = array_intersect_key($source_strings, array_flip($entities));
+                $entities += ShowResults::searchEntities($source_strings, $search->getRegex());
+                $source_results += array_intersect_key($source_strings, array_flip($entities));
             } else {
-                $source_strings = $search->grep($source_strings);
-                $entities = array_keys($source_strings);
+                $source_results += $search->grep($source_strings);
+                $entities += array_keys($source_results);
             }
         }
+        $entities = array_unique($entities);
+        $source_results = array_unique($source_results);
     }
 
     // We have our list of filtered source strings, get corresponding target locale strings
-    $target_strings = array_intersect_key(
+    $target_results = array_intersect_key(
         Utils::getRepoStrings($search->getLocale('target'), $repository),
         array_flip($entities)
     );
 
-    $source_strings_merged = array_merge($source_strings, $source_strings_merged);
-    $target_strings_merged = array_merge($target_strings, $target_strings_merged);
+    $source_results_merged = array_merge($source_results, $source_results_merged);
+    $target_results_merged = array_merge($target_results, $target_results_merged);
     $entities_merged = array_merge($entities, $entities_merged);
 }
 
 // We sort arrays by key before array_splice() to keep matching keys
-ksort($source_strings_merged);
-ksort($target_strings_merged);
+ksort($source_results_merged);
+ksort($target_results_merged);
 
-// Limit results to 200
-array_splice($source_strings_merged, 500);
-array_splice($target_strings_merged, 500);
+// Limit results to 500
+array_splice($source_results_merged, 500);
+array_splice($target_results_merged, 500);
 
 return ShowResults::getRepositorySearchResults(
     $entities_merged,
-    [$source_strings_merged, $target_strings_merged]
+    [$source_results_merged, $target_results_merged]
 );

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -23,7 +23,7 @@ $search
     ->setSearchTerms(urldecode(Utils::cleanString($request->parameters[6])))
     ->setDistinctWords($get_option('distinct_words'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
-    ->setRegexPerfectMatch($get_option('perfect_match'))
+    ->setRegexEntireString($get_option('entire_string'))
     ->setSearchType($request->parameters[2])
     ->setLocales([$request->parameters[4], $request->parameters[5]]);
 
@@ -33,7 +33,7 @@ foreach ($repositories as $repository) {
     $entities = [];
     $source_results = [];
 
-    if ($search->isPerfectMatch()) {
+    if ($search->isEntireString()) {
         if ($search->getSearchType() == 'entities') {
             $entities = ShowResults::searchEntities($source_strings, $search->getRegex());
             $source_results = array_intersect_key($source_strings, array_flip($entities));

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -24,6 +24,7 @@ $search
     ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
+    ->setRegexEntireWords($get_option('entire_words'))
     ->setSearchType($request->parameters[2])
     ->setLocales([$request->parameters[4], $request->parameters[5]]);
 

--- a/app/models/api/repository_search.php
+++ b/app/models/api/repository_search.php
@@ -21,7 +21,7 @@ $target_results_merged = [];
 // Define our search terms and parameters
 $search
     ->setSearchTerms(urldecode(Utils::cleanString($request->parameters[6])))
-    ->setDistinctWords($get_option('distinct_words'))
+    ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
     ->setSearchType($request->parameters[2])
@@ -42,7 +42,7 @@ foreach ($repositories as $repository) {
             $entities = array_keys($source_results);
         }
     } else {
-        $search_terms = $search->isDistinctWords()
+        $search_terms = $search->isEachWord()
             ? Utils::uniqueWords($search->getSearchTerms())
             : [$search->getSearchTerms()];
 

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -22,7 +22,7 @@ $search
     ->setSearchTerms(Utils::cleanString($request->parameters[5]))
     ->setDistinctWords($get_option('distinct_words'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
-    ->setRegexPerfectMatch($get_option('perfect_match'))
+    ->setRegexEntireString($get_option('entire_string'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);
 
 $terms = Utils::uniqueWords($search->getSearchTerms());

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -20,7 +20,7 @@ $target_strings_merged = [];
 // Define our search terms and parameters
 $search
     ->setSearchTerms(Utils::cleanString($request->parameters[5]))
-    ->setRegexWholeWords($get_option('whole_word'))
+    ->setDistinctWords($get_option('distinct_words'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexPerfectMatch($get_option('perfect_match'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -20,7 +20,7 @@ $target_strings_merged = [];
 // Define our search terms and parameters
 $search
     ->setSearchTerms(Utils::cleanString($request->parameters[5]))
-    ->setDistinctWords($get_option('distinct_words'))
+    ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);

--- a/app/models/api/suggestions.php
+++ b/app/models/api/suggestions.php
@@ -23,6 +23,7 @@ $search
     ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
+    ->setRegexEntireWords($get_option('entire_words'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);
 
 $terms = Utils::uniqueWords($search->getSearchTerms());

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -24,7 +24,7 @@ $search
     ->setSearchTerms(Utils::cleanString($request->parameters[5]))
     ->setDistinctWords($get_option('distinct_words'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
-    ->setRegexPerfectMatch($get_option('perfect_match'))
+    ->setRegexEntireString($get_option('entire_string'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);
 
 // We loop through all repositories and merge the results

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -25,6 +25,7 @@ $search
     ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
+    ->setRegexEntireWords($get_option('entire_words'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);
 
 // We loop through all repositories and merge the results

--- a/app/models/api/translation_memory.php
+++ b/app/models/api/translation_memory.php
@@ -22,7 +22,7 @@ $output = [];
 // Define our search terms and parameters
 $search
     ->setSearchTerms(Utils::cleanString($request->parameters[5]))
-    ->setDistinctWords($get_option('distinct_words'))
+    ->setEachWord($get_option('each_word'))
     ->setRegexCaseInsensitive($get_option('case_sensitive'))
     ->setRegexEntireString($get_option('entire_string'))
     ->setLocales([$request->parameters[3], $request->parameters[4]]);
@@ -32,7 +32,7 @@ foreach ($repositories as $repository) {
     $source_strings = Utils::getRepoStrings($search->getLocale('source'), $repository);
     $source_results = [];
 
-    $search_terms = $search->isDistinctWords()
+    $search_terms = $search->isEachWord()
         ? Utils::uniqueWords($search->getSearchTerms())
         : [$search->getSearchTerms()];
     foreach ($search_terms as $word) {

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -7,7 +7,10 @@ if ($search->isPerfectMatch()) {
 } else {
     $locale1_strings = $tmx_source;
     $locale2_strings = $tmx_target;
-    foreach (Utils::uniqueWords($search->getSearchTerms()) as $word) {
+    $search_terms = $search->isDistinctWords()
+        ? Utils::uniqueWords($search->getSearchTerms())
+        : [$search->getSearchTerms()];
+    foreach ($search_terms as $word) {
         $search->setRegexSearchTerms($word);
         $locale1_strings = $search->grep($locale1_strings);
         $locale2_strings = $search->grep($locale2_strings);

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -1,7 +1,7 @@
 <?php
 namespace Transvision;
 
-if ($search->isPerfectMatch()) {
+if ($search->isEntireString()) {
     $locale1_strings = $search->grep($tmx_source);
     $locale2_strings = $search->grep($tmx_target);
 } else {

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -7,7 +7,7 @@ if ($search->isEntireString()) {
 } else {
     $locale1_strings = $tmx_source;
     $locale2_strings = $tmx_target;
-    $search_terms = $search->isDistinctWords()
+    $search_terms = $search->isEachWord()
         ? Utils::uniqueWords($search->getSearchTerms())
         : [$search->getSearchTerms()];
     foreach ($search_terms as $word) {

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -35,7 +35,7 @@ if ($error_count > 0) {
                           "&locale={$locale}" .
                           "&repo={$repo}" .
                           "&search_type=entities&recherche={$string_id}" .
-                          "&perfect_match=perfect_match";
+                          "&entire_string=entire_string";
         $bugzilla_link = Bugzilla::reportErrorLink(
             $locale, $string_id, $source[$string_id],
             $target[$string_id], $repo, $string_id_link

--- a/app/views/consistency.php
+++ b/app/views/consistency.php
@@ -59,7 +59,7 @@ if ($strings_number == 0) {
         . "&locale={$locale}"
         . "&repo={$repo}"
         . '&search_type=strings&recherche=' . urlencode($data['source'])
-        . '&perfect_match=perfect_match';
+        . '&entire_string=entire_string';
         echo "<tr>\n";
         echo '<td>';
         echo '<a href="' . $search_link . '" title="Search for this string">' . Utils::secureText($data['source']) . "</a></td>\n";

--- a/app/views/empty_strings.php
+++ b/app/views/empty_strings.php
@@ -70,7 +70,7 @@ if (count($empty_strings) == 0) {
         . "&locale={$locale}"
         . "&repo={$repo}"
         . "&search_type=entities&recherche={$key}"
-        . "&perfect_match=perfect_match";
+        . "&entire_string=entire_string";
 
         $bugzilla_link = [Bugzilla::reportErrorLink(
             $locale, $key, $reference_string, $locale_string, $repo, $entity_link

--- a/app/views/onestring.php
+++ b/app/views/onestring.php
@@ -29,7 +29,7 @@ include VIEWS . 'templates/api_promotion.php';
     $reference_locale = Project::getReferenceLocale($repo);
     foreach ($translations as $locale => $translation) {
         $rtl_support = RTLSupport::isRTL($locale) ? 'dir="rtl"' : '';
-        $search_link = "/?sourcelocale={$reference_locale}&locale={$locale}&repo={$repo}&search_type=entities&recherche={$entity}&perfect_match=perfect_match";
+        $search_link = "/?sourcelocale={$reference_locale}&locale={$locale}&repo={$repo}&search_type=entities&recherche={$entity}&entire_string=entire_string";
         echo "<tr id='{$locale}'>\n" .
              "  <th><a href='#{$locale}'>{$locale}</a></th>\n";
 

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -80,7 +80,7 @@ foreach ($entities as $entity) {
                      . "&locale={$locale2}"
                      . "&repo={$current_repo}"
                      . "&search_type=entities&recherche={$entity}"
-                     . "&perfect_match=perfect_match";
+                     . "&entire_string=entire_string";
 
         $file_bug = '<a class="bug_link" target="_blank" href="'
                     . Bugzilla::reportErrorLink($locale2, $entity, $source_string,
@@ -122,7 +122,7 @@ foreach ($entities as $entity) {
                  . "&locale={$locale}"
                  . "&repo={$current_repo}"
                  . "&search_type=entities&recherche={$entity}"
-                 . "&perfect_match=perfect_match";
+                 . "&entire_string=entire_string";
 
     $file_bug = '<a class="bug_link" target="_blank" href="'
                 . Bugzilla::reportErrorLink($locale, $entity, $source_string,

--- a/app/views/results_glossary.php
+++ b/app/views/results_glossary.php
@@ -27,7 +27,7 @@ if (count($perfect_results) > 0) {
         . "&locale={$locale}"
         . "&repo={$repo}"
         . "&search_type=entities&recherche={$string_id}"
-        . "&perfect_match=perfect_match";
+        . "&entire_string=entire_string";
 
         echo "<tr>\n";
         echo "  <td dir='{$locale_dir}'><span class='celltitle'>Localized string</span><div class='string'><a href='{$entity_link}'>" . Utils::secureText($string_value) . "</a></div></td>\n";

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 $proposed_search = $_GET;
 // Reset advanced search options (no need to check in advance if they're set)
-unset($proposed_search['case_sensitive'], $proposed_search['perfect_match'], $proposed_search['whole_word']);
+unset($proposed_search['case_sensitive'], $proposed_search['perfect_match'], $proposed_search['distinct_words']);
 
 $list_items = '';
 foreach ($best_matches as $match) {

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 $proposed_search = $_GET;
 // Reset advanced search options (no need to check in advance if they're set)
-unset($proposed_search['case_sensitive'], $proposed_search['perfect_match'], $proposed_search['distinct_words']);
+unset($proposed_search['case_sensitive'], $proposed_search['entire_string'], $proposed_search['distinct_words']);
 
 $list_items = '';
 foreach ($best_matches as $match) {

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 $proposed_search = $_GET;
 // Reset advanced search options (no need to check in advance if they're set)
-unset($proposed_search['case_sensitive'], $proposed_search['entire_string'], $proposed_search['each_word']);
+unset($proposed_search['case_sensitive'], $proposed_search['entire_string'], $proposed_search['each_word'], $proposed_search['entire_words']);
 
 $list_items = '';
 foreach ($best_matches as $match) {

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -3,7 +3,7 @@ namespace Transvision;
 
 $proposed_search = $_GET;
 // Reset advanced search options (no need to check in advance if they're set)
-unset($proposed_search['case_sensitive'], $proposed_search['entire_string'], $proposed_search['distinct_words']);
+unset($proposed_search['case_sensitive'], $proposed_search['entire_string'], $proposed_search['each_word']);
 
 $list_items = '';
 foreach ($best_matches as $match) {

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -147,7 +147,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                <?=Utils::checkboxState($check['each_word'])?>
                         />
                         <label for="each_word" aria-describedby="tooltip_eachword">Each Word</label>
-                        <div id="tooltip_earchword" class="search_tooltip" role="tooltip">If selected, search for <strong>each word</strong> in the search query (at least 2 characters long). By default, the search query is used as a whole.</div>
+                        <div id="tooltip_eachword" class="search_tooltip" role="tooltip">If selected, search for <strong>each word</strong> in the search query (at least 2 characters long). By default, the search query is used as a whole.</div>
                     </span>
                     <span>
                         <input type="checkbox"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -140,14 +140,14 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                     </span>
                     <span>
                         <input type="checkbox"
-                               name="distinct_words"
-                               id="distinct_words"
-                               value="distinct_words"
+                               name="each_word"
+                               id="each_word"
+                               value="each_word"
                                class="search_options"
-                               <?=Utils::checkboxState($check['distinct_words'])?>
+                               <?=Utils::checkboxState($check['each_word'])?>
                         />
-                        <label for="distinct_words" aria-describedby="tooltip_distinct">Distinct Words</label>
-                        <div id="tooltip_distinct" class="search_tooltip" role="tooltip">If selected, <strong>search for each word</strong> (at least 2 characters long). By default, the search query is used as a whole.</div>
+                        <label for="each_word" aria-describedby="tooltip_eachword">Each Word</label>
+                        <div id="tooltip_earchword" class="search_tooltip" role="tooltip">If selected, search for <strong>each word</strong> in the search query (at least 2 characters long). By default, the search query is used as a whole.</div>
                     </span>
                     <span>
                         <input type="checkbox"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -157,8 +157,19 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                class="search_options"
                                <?=Utils::checkboxState($check['entire_string'])?>
                         />
-                        <label for="entire_string" aria-describedby="tooltip_entire">Entire String</label>
-                        <div id="tooltip_entire" class="search_tooltip" role="tooltip">If selected, the <strong>entire string</strong> needs to match the search query. By default, partial matches are included in the results.</div>
+                        <label for="entire_string" aria-describedby="tooltip_entirestring">Entire String</label>
+                        <div id="tooltip_entirestring" class="search_tooltip" role="tooltip">If selected, the <strong>entire string</strong> needs to match the search query. By default, partial matches are included in the results.</div>
+                    </span>
+                    <span>
+                        <input type="checkbox"
+                               name="entire_words"
+                               id="entire_words"
+                               value="entire_words"
+                               class="search_options"
+                               <?=Utils::checkboxState($check['entire_words'])?>
+                        />
+                        <label for="entire_words" aria-describedby="tooltip_entirewords">Entire Words</label>
+                        <div id="tooltip_entirewords" class="search_tooltip" role="tooltip">If selected, each search term needs to match an <strong>entire word</strong>. By default, partial word matches are included in the results.</div>
                     </span>
                     <?php if ($check['t2t'] == 't2t') :?>
                     <input type="hidden"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -151,14 +151,14 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                     </span>
                     <span>
                         <input type="checkbox"
-                               name="perfect_match"
-                               id="perfect_match"
-                               value="perfect_match"
+                               name="entire_string"
+                               id="entire_string"
+                               value="entire_string"
                                class="search_options"
-                               <?=Utils::checkboxState($check['perfect_match'])?>
+                               <?=Utils::checkboxState($check['entire_string'])?>
                         />
-                        <label for="perfect_match" aria-describedby="tooltip_perfect">Perfect Match</label>
-                        <div id="tooltip_perfect" class="search_tooltip" role="tooltip">If selected, the entire string needs to <strong>perfectly match</strong> the search query. By default, partial matches are included in the results.</div>
+                        <label for="entire_string" aria-describedby="tooltip_entire">Entire String</label>
+                        <div id="tooltip_entire" class="search_tooltip" role="tooltip">If selected, the <strong>entire string</strong> needs to match the search query. By default, partial matches are included in the results.</div>
                     </span>
                     <?php if ($check['t2t'] == 't2t') :?>
                     <input type="hidden"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -136,7 +136,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                <?=Utils::checkboxState($check['case_sensitive'])?>
                          />
                         <label for="case_sensitive" aria-describedby="tooltip_case">Case Sensitive</label>
-                        <div id="tooltip_case" class="search_tooltip" role="tooltip">If selected, search with the exact case used in search query. By default, case is ignored.</div>
+                        <div id="tooltip_case" class="search_tooltip" role="tooltip">If selected, search with the <strong>exact case</strong> used in the search query. By default, case is ignored.</div>
                     </span>
                     <span>
                         <input type="checkbox"
@@ -147,7 +147,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                <?=Utils::checkboxState($check['distinct_words'])?>
                         />
                         <label for="distinct_words" aria-describedby="tooltip_distinct">Distinct Words</label>
-                        <div id="tooltip_distinct" class="search_tooltip" role="tooltip">If selected, search for each single word separately. By default, the search query is used as a whole.</div>
+                        <div id="tooltip_distinct" class="search_tooltip" role="tooltip">If selected, <strong>search for each word</strong> (at least 2 characters long). By default, the search query is used as a whole.</div>
                     </span>
                     <span>
                         <input type="checkbox"
@@ -158,7 +158,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                <?=Utils::checkboxState($check['perfect_match'])?>
                         />
                         <label for="perfect_match" aria-describedby="tooltip_perfect">Perfect Match</label>
-                        <div id="tooltip_perfect" class="search_tooltip" role="tooltip">If selected, search for a perfect match. By default, partial matches are included in the results.</div>
+                        <div id="tooltip_perfect" class="search_tooltip" role="tooltip">If selected, the entire string needs to <strong>perfectly match</strong> the search query. By default, partial matches are included in the results.</div>
                     </span>
                     <?php if ($check['t2t'] == 't2t') :?>
                     <input type="hidden"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -134,7 +134,8 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                value="case_sensitive"
                                <?=Utils::checkboxState($check['case_sensitive'])?>
                          />
-                        <label for="case_sensitive">Case Sensitive</label>
+                        <label for="case_sensitive" aria-describedby="tooltip_case">Case Sensitive</label>
+                        <div id="tooltip_case" class="search_tooltip" role="tooltip">If selected, search with the exact case used in search query. By default, case is ignored.</div>
                     </span>
                     <span>
                         <input type="checkbox"
@@ -143,7 +144,8 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                value="distinct_words"
                                <?=Utils::checkboxState($check['distinct_words'])?>
                         />
-                        <label for="distinct_words">Distinct Words</label>
+                        <label for="distinct_words" aria-describedby="tooltip_distinct">Distinct Words</label>
+                        <div id="tooltip_distinct" class="search_tooltip" role="tooltip">If selected, search for each single word separately. By default, the search query is used as a whole.</div>
                     </span>
                     <span>
                         <input type="checkbox"
@@ -152,9 +154,9 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                value="perfect_match"
                                <?=Utils::checkboxState($check['perfect_match'])?>
                         />
-                        <label for="perfect_match">Perfect Match</label>
+                        <label for="perfect_match" aria-describedby="tooltip_perfect">Perfect Match</label>
+                        <div id="tooltip_perfect" class="search_tooltip" role="tooltip">If selected, search for a perfect match. By default, partial matches are included in the results.</div>
                     </span>
-
                     <?php if ($check['t2t'] == 't2t') :?>
                     <input type="hidden"
                            name="t2t"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -138,12 +138,12 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                     </span>
                     <span>
                         <input type="checkbox"
-                               name="whole_word"
-                               id="whole_word"
-                               value="whole_word"
-                               <?=Utils::checkboxState($check['whole_word'])?>
+                               name="distinct_words"
+                               id="distinct_words"
+                               value="distinct_words"
+                               <?=Utils::checkboxState($check['distinct_words'])?>
                         />
-                        <label for="whole_word">Whole Word</label>
+                        <label for="distinct_words">Distinct Words</label>
                     </span>
                     <span>
                         <input type="checkbox"

--- a/app/views/search_form.php
+++ b/app/views/search_form.php
@@ -132,6 +132,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                name="case_sensitive"
                                id="case_sensitive"
                                value="case_sensitive"
+                               class="search_options"
                                <?=Utils::checkboxState($check['case_sensitive'])?>
                          />
                         <label for="case_sensitive" aria-describedby="tooltip_case">Case Sensitive</label>
@@ -142,6 +143,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                name="distinct_words"
                                id="distinct_words"
                                value="distinct_words"
+                               class="search_options"
                                <?=Utils::checkboxState($check['distinct_words'])?>
                         />
                         <label for="distinct_words" aria-describedby="tooltip_distinct">Distinct Words</label>
@@ -152,6 +154,7 @@ $cookie_option = function ($cookie, $locale) use ($search) {
                                name="perfect_match"
                                id="perfect_match"
                                value="perfect_match"
+                               class="search_options"
                                <?=Utils::checkboxState($check['perfect_match'])?>
                         />
                         <label for="perfect_match" aria-describedby="tooltip_perfect">Perfect Match</label>

--- a/app/views/templates/api_promotion.php
+++ b/app/views/templates/api_promotion.php
@@ -4,7 +4,7 @@ namespace Transvision;
 if ($controller == 'mainsearch'):
 ?>
 <p class="api_link">
-    <span>API</span>These results are also available as an API request for
+    <span>API</span>These results are also available as an API request to search in
     <a href="<?=Utils::APIPromotion($source_locale, $locale)?>"><?=$source_locale?></a> or
     <a href="<?=Utils::APIPromotion($locale, $source_locale)?>"><?=$locale?></a>.
     <br>

--- a/app/views/unchanged_strings.php
+++ b/app/views/unchanged_strings.php
@@ -33,7 +33,7 @@ foreach ($unchanged_strings as $string_id => $string_value) {
             . "&locale={$locale}"
             . "&repo={$repo}"
             . "&search_type=entities&recherche={$string_id}"
-            . "&perfect_match=perfect_match";
+            . "&entire_string=entire_string";
 
     /*
         Since this view displays strings identical to source locale, I'll use the same

--- a/app/views/unlocalized_words.php
+++ b/app/views/unlocalized_words.php
@@ -20,7 +20,7 @@ include __DIR__ . '/simplesearchform.php';
 <?php foreach ($unlocalized_words as $english_term => $locales) :
     $string_count = $locales[$locale];
     $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-            "&locale={$ref_locale}&search_type=strings&whole_word=whole_word";
+            "&locale={$ref_locale}&search_type=strings&distinct_words=1";
 
     $link_title = $string_count == 1
         ? 'Search for this occurrence'

--- a/app/views/unlocalized_words.php
+++ b/app/views/unlocalized_words.php
@@ -20,7 +20,7 @@ include __DIR__ . '/simplesearchform.php';
 <?php foreach ($unlocalized_words as $english_term => $locales) :
     $string_count = $locales[$locale];
     $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-            "&locale={$ref_locale}&search_type=strings&distinct_words=1";
+            "&locale={$ref_locale}&search_type=strings&distinct_words=distinct_words";
 
     $link_title = $string_count == 1
         ? 'Search for this occurrence'

--- a/app/views/unlocalized_words.php
+++ b/app/views/unlocalized_words.php
@@ -20,7 +20,7 @@ include __DIR__ . '/simplesearchform.php';
 <?php foreach ($unlocalized_words as $english_term => $locales) :
     $string_count = $locales[$locale];
     $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-            "&locale={$ref_locale}&search_type=strings&distinct_words=distinct_words";
+            "&locale={$ref_locale}&search_type=strings";
 
     $link_title = $string_count == 1
         ? 'Search for this occurrence'

--- a/app/views/unlocalized_words.php
+++ b/app/views/unlocalized_words.php
@@ -20,7 +20,7 @@ include __DIR__ . '/simplesearchform.php';
 <?php foreach ($unlocalized_words as $english_term => $locales) :
     $string_count = $locales[$locale];
     $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-            "&locale={$ref_locale}&search_type=strings";
+            "&locale={$ref_locale}&search_type=strings&entire_words=entire_words";
 
     $link_title = $string_count == 1
         ? 'Search for this occurrence'

--- a/app/views/unlocalized_words_all.php
+++ b/app/views/unlocalized_words_all.php
@@ -36,7 +36,7 @@ include __DIR__ . '/simplesearchform.php';
             }
 
             $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-                    "&locale={$ref_locale}&search_type=strings";
+                    "&locale={$ref_locale}&search_type=strings&entire_words=entire_words";
 
             if ($count > 0) {
                 print "<td><a href='{$link}'>{$count}</a></td>";

--- a/app/views/unlocalized_words_all.php
+++ b/app/views/unlocalized_words_all.php
@@ -36,7 +36,7 @@ include __DIR__ . '/simplesearchform.php';
             }
 
             $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-                    "&locale={$ref_locale}&search_type=strings&whole_word=whole_word";
+                    "&locale={$ref_locale}&search_type=strings&distinct_words=1";
 
             if ($count > 0) {
                 print "<td><a href='{$link}'>{$count}</a></td>";

--- a/app/views/unlocalized_words_all.php
+++ b/app/views/unlocalized_words_all.php
@@ -36,7 +36,7 @@ include __DIR__ . '/simplesearchform.php';
             }
 
             $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-                    "&locale={$ref_locale}&search_type=strings&distinct_words=1";
+                    "&locale={$ref_locale}&search_type=strings&distinct_words=distinct_words";
 
             if ($count > 0) {
                 print "<td><a href='{$link}'>{$count}</a></td>";

--- a/app/views/unlocalized_words_all.php
+++ b/app/views/unlocalized_words_all.php
@@ -36,7 +36,7 @@ include __DIR__ . '/simplesearchform.php';
             }
 
             $link = "/?recherche={$english_term}&repo={$repo}&sourcelocale={$locale}" .
-                    "&locale={$ref_locale}&search_type=strings&distinct_words=distinct_words";
+                    "&locale={$ref_locale}&search_type=strings";
 
             if ($count > 0) {
                 print "<td><a href='{$link}'>{$count}</a></td>";

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -21,7 +21,7 @@ class Search extends atoum\test
             ->string($obj->getRegexCase())
                 ->isEqualTo('i');
         $this
-            ->boolean($obj->isDistinctWords())
+            ->boolean($obj->isEachWord())
                 ->isEqualTo(false);
         $this
             ->boolean($obj->isEntireString())
@@ -40,10 +40,10 @@ class Search extends atoum\test
                 ->isEqualTo('');
         $this
             ->array($obj->getFormSearchOptions())
-                ->isEqualTo(['case_sensitive', 'entire_string', 'repo', 'search_type', 't2t', 'distinct_words']);
+                ->isEqualTo(['case_sensitive', 'entire_string', 'repo', 'search_type', 't2t', 'each_word']);
         $this
             ->array($obj->getFormCheckboxes())
-                ->isEqualTo(['case_sensitive', 'entire_string', 't2t', 'distinct_words']);
+                ->isEqualTo(['case_sensitive', 'entire_string', 't2t', 'each_word']);
     }
 
     public function testSetSearchTerms()

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -21,8 +21,8 @@ class Search extends atoum\test
             ->string($obj->getRegexCase())
                 ->isEqualTo('i');
         $this
-            ->string($obj->isWholeWords())
-                ->isEqualTo('');
+            ->boolean($obj->isDistinctWords())
+                ->isEqualTo(false);
         $this
             ->boolean($obj->isPerfectMatch())
                 ->isEqualTo(false);
@@ -40,10 +40,10 @@ class Search extends atoum\test
                 ->isEqualTo('');
         $this
             ->array($obj->getFormSearchOptions())
-                ->isEqualTo(['case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'whole_word']);
+                ->isEqualTo(['case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'distinct_words']);
         $this
             ->array($obj->getFormCheckboxes())
-                ->isEqualTo(['case_sensitive', 'perfect_match', 't2t', 'whole_word']);
+                ->isEqualTo(['case_sensitive', 'perfect_match', 't2t', 'distinct_words']);
     }
 
     public function testSetSearchTerms()
@@ -114,37 +114,17 @@ class Search extends atoum\test
                 ->isEqualTo('~~iu');
     }
 
-    public function testSetRegexWholeWords()
-    {
-        $obj = new _Search();
-        $obj->setRegexWholeWords('whole_word');
-        $this
-            ->string($obj->isWholeWords())
-                ->isEqualTo(true)
-            ->string($obj->getRegex())
-                ->isEqualTo('~\b\b~iu');
-
-        $obj->setRegexWholeWords(false);
-        $this
-            ->string($obj->isWholeWords())
-                ->isEqualTo(false)
-            ->string($obj->getRegex())
-                ->isEqualTo('~~iu');
-    }
-
     public function testMultipleRegexChanges()
     {
         $obj = new _Search();
         $obj
             ->setSearchTerms('A new hope')
-            ->setRegexWholeWords('whole_word')
             ->setRegexPerfectMatch(false)
             ->setRegexCaseInsensitive('sensitive');
         $this->string($obj->getRegex())
-                ->isEqualTo('~\bA new hope\b~u');
+                ->isEqualTo('~A new hope~u');
 
         $obj->setSearchTerms('Return of the jedi')
-            ->setRegexWholeWords('')
             ->setRegexPerfectMatch(true)
             ->setRegexCaseInsensitive('');
         $this
@@ -157,19 +137,29 @@ class Search extends atoum\test
         include_once TMX . 'fr/cache_fr_central.php';
         $obj = new _Search();
         $obj
-            ->setSearchTerms('Marque')
-            ->setRegexWholeWords('whole_word');
+            ->setSearchTerms('marque');
         $this->array($obj->grep($tmx))
             ->isEqualTo(
                 [
+                    'mobile/android/base/android_strings.dtd:bookmark'                                => 'Marquer cette page',
                     'browser/chrome/browser/places/places.properties:bookmarkResultLabel'             => 'Marque-page',
                     'browser/chrome/browser/syncQuota.properties:collection.bookmarks.label'          => 'Marque-pages',
                     'browser/chrome/browser/places/bookmarkProperties.properties:dialogTitleAddMulti' => 'Nouveaux marque-pages',
+                    'browser/chrome/browser/browser.dtd:bookmarkThisPageCmd.label'                    => 'Marquer cette page',
                 ]
             );
 
         $obj
-            ->setRegexWholeWords('')
+            ->setSearchTerms('marquer cette');
+        $this->array($obj->grep($tmx))
+            ->isEqualTo(
+                [
+                    'mobile/android/base/android_strings.dtd:bookmark'             => 'Marquer cette page',
+                    'browser/chrome/browser/browser.dtd:bookmarkThisPageCmd.label' => 'Marquer cette page',
+                ]
+            );
+
+        $obj
             ->setSearchTerms('...')
             ->setRegexPerfectMatch('perfect_match');
 

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -43,14 +43,14 @@ class Search extends atoum\test
                 ->isEqualTo(
                     [
                         'case_sensitive', 'entire_string', 'repo',
-                        'search_type', 't2t', 'each_word', 'entire_words'
+                        'search_type', 't2t', 'each_word', 'entire_words',
                     ]);
         $this
             ->array($obj->getFormCheckboxes())
                 ->isEqualTo(
                     [
                         'case_sensitive', 'entire_string', 't2t',
-                        'each_word', 'entire_words'
+                        'each_word', 'entire_words',
                     ]);
     }
 

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -24,7 +24,7 @@ class Search extends atoum\test
             ->boolean($obj->isDistinctWords())
                 ->isEqualTo(false);
         $this
-            ->boolean($obj->isPerfectMatch())
+            ->boolean($obj->isEntireString())
                 ->isEqualTo(false);
         $this
             ->string($obj->getRegexSearchTerms())
@@ -40,10 +40,10 @@ class Search extends atoum\test
                 ->isEqualTo('');
         $this
             ->array($obj->getFormSearchOptions())
-                ->isEqualTo(['case_sensitive', 'perfect_match', 'repo', 'search_type', 't2t', 'distinct_words']);
+                ->isEqualTo(['case_sensitive', 'entire_string', 'repo', 'search_type', 't2t', 'distinct_words']);
         $this
             ->array($obj->getFormCheckboxes())
-                ->isEqualTo(['case_sensitive', 'perfect_match', 't2t', 'distinct_words']);
+                ->isEqualTo(['case_sensitive', 'entire_string', 't2t', 'distinct_words']);
     }
 
     public function testSetSearchTerms()
@@ -96,19 +96,19 @@ class Search extends atoum\test
                 ->isEqualTo('~~iu');
     }
 
-    public function testSetRegexPerfectMatch()
+    public function testSetRegexEntireString()
     {
         $obj = new _Search();
-        $obj->setRegexPerfectMatch('perfect_match');
+        $obj->setRegexEntireString('entire_string');
         $this
-            ->boolean($obj->isPerfectMatch())
+            ->boolean($obj->isEntireString())
                 ->isEqualTo(true)
             ->string($obj->getRegex())
                 ->isEqualTo('~^$~iu');
 
-        $obj->setRegexPerfectMatch(false);
+        $obj->setRegexEntireString(false);
         $this
-            ->boolean($obj->isPerfectMatch())
+            ->boolean($obj->isEntireString())
                 ->isEqualTo(false)
             ->string($obj->getRegex())
                 ->isEqualTo('~~iu');
@@ -119,13 +119,13 @@ class Search extends atoum\test
         $obj = new _Search();
         $obj
             ->setSearchTerms('A new hope')
-            ->setRegexPerfectMatch(false)
+            ->setRegexEntireString(false)
             ->setRegexCaseInsensitive('sensitive');
         $this->string($obj->getRegex())
                 ->isEqualTo('~A new hope~u');
 
         $obj->setSearchTerms('Return of the jedi')
-            ->setRegexPerfectMatch(true)
+            ->setRegexEntireString(true)
             ->setRegexCaseInsensitive('');
         $this
             ->string($obj->getRegex())
@@ -161,7 +161,7 @@ class Search extends atoum\test
 
         $obj
             ->setSearchTerms('...')
-            ->setRegexPerfectMatch('perfect_match');
+            ->setRegexEntireString('entire_string');
 
         $this->array($obj->grep($tmx))
             ->isEqualTo(

--- a/tests/units/Transvision/Search.php
+++ b/tests/units/Transvision/Search.php
@@ -18,8 +18,8 @@ class Search extends atoum\test
             ->string($obj->getRegex())
                 ->isEqualTo('');
         $this
-            ->string($obj->getRegexCase())
-                ->isEqualTo('i');
+            ->boolean($obj->isCaseSensitive())
+                ->isEqualTo(false);
         $this
             ->boolean($obj->isEachWord())
                 ->isEqualTo(false);
@@ -40,10 +40,18 @@ class Search extends atoum\test
                 ->isEqualTo('');
         $this
             ->array($obj->getFormSearchOptions())
-                ->isEqualTo(['case_sensitive', 'entire_string', 'repo', 'search_type', 't2t', 'each_word']);
+                ->isEqualTo(
+                    [
+                        'case_sensitive', 'entire_string', 'repo',
+                        'search_type', 't2t', 'each_word', 'entire_words'
+                    ]);
         $this
             ->array($obj->getFormCheckboxes())
-                ->isEqualTo(['case_sensitive', 'entire_string', 't2t', 'each_word']);
+                ->isEqualTo(
+                    [
+                        'case_sensitive', 'entire_string', 't2t',
+                        'each_word', 'entire_words'
+                    ]);
     }
 
     public function testSetSearchTerms()
@@ -92,6 +100,25 @@ class Search extends atoum\test
 
         $obj->setRegexCaseInsensitive(false);
         $this
+            ->string($obj->getRegex())
+                ->isEqualTo('~~iu');
+    }
+
+    public function testSetRegexEntireWords()
+    {
+        $obj = new _Search();
+        $obj->setRegexEntireWords('entire_words');
+
+        $this
+            ->boolean($obj->isEntireWords())
+                ->isEqualTo(true)
+            ->string($obj->getRegex())
+                ->isEqualTo('~\b\b~iu');
+
+        $obj->setRegexEntireWords(false);
+        $this
+            ->boolean($obj->isEntireWords())
+                ->isEqualTo(false)
             ->string($obj->getRegex())
                 ->isEqualTo('~~iu');
     }

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -31,25 +31,31 @@ class Utils extends atoum\test
 
     public function uniqueWordsDP()
     {
-        return ['achat des couteaux suisses'];
+        return [
+            [
+                'achat des couteaux suisses',
+                ['couteaux', 'suisses', 'achat', 'des'],
+            ],
+            [
+                'achat     des  couteaux suisses   ',
+                ['couteaux', 'suisses', 'achat', 'des'],
+            ],
+            [
+                'Set a cookie',
+                ['cookie', 'Set'],
+            ],
+        ];
     }
 
     /**
      * @dataProvider uniqueWordsDP
      */
-    public function testUniqueWords($a)
+    public function testUniqueWords($a, $b)
     {
         $obj = new _Utils();
         $this
             ->array($obj->uniqueWords($a))
-                ->isEqualTo(
-                    [
-                        'couteaux',
-                        'suisses',
-                        'achat',
-                        'des',
-                    ]
-                );
+                ->isEqualTo($b);
     }
 
     public function checkboxDefaultOption1DP()

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -478,8 +478,8 @@ class Utils extends atoum\test
             [
                 'it',
                 'en-US',
-                '/?recherche=Cookies&repo=aurora&sourcelocale=en-US&locale=it&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&perfect_match=perfect_match',
-                '/?recherche=Cookies&repo=aurora&sourcelocale=it&locale=en-US&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&perfect_match=perfect_match&json=true',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=en-US&locale=it&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&entire_string=entire_string',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=it&locale=en-US&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&entire_string=entire_string&json=true',
             ],
         ];
     }

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -464,28 +464,32 @@ class Utils extends atoum\test
     {
         return [
             [
+                'en-US',
+                'fr',
                 '/?recherche=test&repo=aurora&sourcelocale=fr&locale=en-US&search_type=strings',
-                '/?recherche=test&repo=aurora&sourcelocale=fr&locale=en-US&search_type=strings&json=true',
+                '/?recherche=test&repo=aurora&sourcelocale=en-US&locale=fr&search_type=strings&json=true',
             ],
             [
-                '/?whole_word=on&sourcelocale=af&repo=beta&case_sensitive=on&perfect_match=on&locale=af&search_type=entities&recherche=555-555-0199@example.com&%22%3E%3Cscript%3Ealert%281%29%3C/script%3E=1',
-                '/?whole_word=on&sourcelocale=fr&repo=beta&case_sensitive=on&perfect_match=on&locale=en-US&search_type=entities&recherche=555-555-0199@example.com&&amp;#34;&amp;#62;&amp;#60;script&amp;#62;alert(1)&amp;#60;/script&amp;#62;=1&json=true',
+                'it',
+                'en-US',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=en-US&locale=it&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&perfect_match=perfect_match',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=it&locale=en-US&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&perfect_match=perfect_match&json=true',
             ],
         ];
     }
     /**
      * @dataProvider APIPromotionDP
      */
-    public function testAPIPromotion($a, $b)
+    public function testAPIPromotion($a, $b, $c, $d)
     {
         $obj = new _Utils();
-        $_SERVER['REQUEST_URI'] = $a;
-        $_SERVER['QUERY_STRING'] = isset(parse_url($a)['query'])
-            ? parse_url($a)['query']
+        $_SERVER['REQUEST_URI'] = $c;
+        $_SERVER['QUERY_STRING'] = isset(parse_url($c)['query'])
+            ? parse_url($c)['query']
             : null;
         $this
-            ->string($obj->APIPromotion('en-US', 'fr'))
-                ->isEqualTo($b);
+            ->string($obj->APIPromotion($a, $b))
+                ->isEqualTo($d);
     }
 
     public function testGetScriptPerformances()

--- a/tests/units/Transvision/Utils.php
+++ b/tests/units/Transvision/Utils.php
@@ -478,8 +478,8 @@ class Utils extends atoum\test
             [
                 'it',
                 'en-US',
-                '/?recherche=Cookies&repo=aurora&sourcelocale=en-US&locale=it&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&entire_string=entire_string',
-                '/?recherche=Cookies&repo=aurora&sourcelocale=it&locale=en-US&search_type=strings_entities&case_sensitive=case_sensitive&distinct_words=distinct_words&entire_string=entire_string&json=true',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=en-US&locale=it&search_type=strings_entities&case_sensitive=case_sensitive&each_word=each_word&entire_string=entire_string',
+                '/?recherche=Cookies&repo=aurora&sourcelocale=it&locale=en-US&search_type=strings_entities&case_sensitive=case_sensitive&each_word=each_word&entire_string=entire_string&json=true',
             ],
         ];
     }

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -66,8 +66,8 @@ $(document).ready(function() {
 
     // Some search options are mutually exclusive
     var updateSearchOptions = function() {
-        $('#perfect_match').prop('disabled', $('#distinct_words').prop('checked'));
-        $('#distinct_words').prop('disabled', $('#perfect_match').prop('checked'));
+        $('#entire_string').prop('disabled', $('#distinct_words').prop('checked'));
+        $('#distinct_words').prop('disabled', $('#entire_string').prop('checked'));
     };
     // Call it once when the page is ready, since options are set also via getRepository
     updateSearchOptions();

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -1,8 +1,9 @@
 var checkDefault = function(id) {
-    /* Check if the associated 'default' checkbox needs to be selected.
-     * If the select is called 'repository', the default checkbox
-     * is called 'default_repository'.
-     */
+    /*
+        Check if the associated 'default' checkbox needs to be selected.
+        If the select is called 'repository', the default checkbox
+        is called 'default_repository'.
+    */
     var checkbox = $('#default_' + id);
     var currentValue = $('#' + id).val();
     if (currentValue === checkbox.val()) {
@@ -53,9 +54,10 @@ $(document).ready(function() {
     // Call it once when the page is ready
     checkSuggestions();
 
-    /* Change the label below the search field to reflect the value of "Search in".
-     * Also checks if the default checkbox needs to be selected.
-     */
+    /*
+        Change the label below the search field to reflect the value of "Search in".
+        Also checks if the default checkbox needs to be selected.
+    */
     $('#search_type').on('change', function(){
         var optionLabel = $('#search_type option[value="' + this.value + '"]').text();
         $('#searchcontextvalue').text(optionLabel);
@@ -64,9 +66,14 @@ $(document).ready(function() {
         checkSuggestions();
     });
 
-    // Some search options are mutually exclusive
+    /*
+        Some search options are mutually exclusive.
+        "Entire string" disables both "Entire Words" and "Each Word", and
+        viceversa.
+    */
     var updateSearchOptions = function() {
         $('#entire_string').prop('disabled', $('#each_word').prop('checked'));
+        $('#entire_words').prop('disabled', $('#entire_string').prop('checked'));
         $('#each_word').prop('disabled', $('#entire_string').prop('checked'));
     };
     // Call it once when the page is ready, since options are set also via getRepository
@@ -99,9 +106,10 @@ $(document).ready(function() {
         });
     });
 
-    /* When a locale selector changes, checks if the default checkbox needs
-     * to be selected.
-     */
+    /*
+        When a locale selector changes, checks if the default checkbox needs
+        to be selected.
+    */
     $('.mainsearch_locale_selector').on('change', function(){
         checkDefault(this.id);
     });
@@ -123,9 +131,10 @@ $(document).ready(function() {
             cookieValue = $('#' + selectName).val();
         }
 
-        /* Set Cookie to store default value. Use checkbox ID as cookie
-         * name (e.g. default_repository) and value as content.
-         */
+        /*
+            Set Cookie to store default value. Use checkbox ID as cookie
+            name (e.g. default_repository) and value as content.
+        */
         expire.setTime(today.getTime() + 3600000 * 24 * days);
         document.cookie = cookieName + '=' + cookieValue +
                           ';expires=' + expire.toGMTString();

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -64,6 +64,15 @@ $(document).ready(function() {
         checkSuggestions();
     });
 
+    // Some search options are mutually exclusive
+    var updateSearchOptions = function() {
+        $('#perfect_match').prop('disabled', $('#distinct_words').prop('checked'));
+        $('#distinct_words').prop('disabled', $('#perfect_match').prop('checked'));
+    };
+    // Call it once when the page is ready, since options are set also via getRepository
+    updateSearchOptions();
+    $('.search_options').on('change', updateSearchOptions);
+
     // Associate code to repository switch in main search form.
     $('#repository').on('change', function(){
         var repositoryID = this.value;

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -72,7 +72,7 @@ $(document).ready(function() {
         viceversa.
     */
     var updateSearchOptions = function() {
-        $('#entire_string').prop('disabled', $('#each_word').prop('checked'));
+        $('#entire_string').prop('disabled', $('#each_word').prop('checked') || $('#entire_words').prop('checked'));
         $('#entire_words').prop('disabled', $('#entire_string').prop('checked'));
         $('#each_word').prop('disabled', $('#entire_string').prop('checked'));
     };

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -66,8 +66,8 @@ $(document).ready(function() {
 
     // Some search options are mutually exclusive
     var updateSearchOptions = function() {
-        $('#entire_string').prop('disabled', $('#distinct_words').prop('checked'));
-        $('#distinct_words').prop('disabled', $('#entire_string').prop('checked'));
+        $('#entire_string').prop('disabled', $('#each_word').prop('checked'));
+        $('#each_word').prop('disabled', $('#entire_string').prop('checked'));
     };
     // Call it once when the page is ready, since options are set also via getRepository
     updateSearchOptions();

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -802,7 +802,7 @@ input[type="checkbox"]:disabled + label {
     border-radius: 4px;
     background-color: #0095dd;
     transition: all linear .1s;
-    opacity: 0.75;
+    opacity: 0.85;
 }
 
 .search_tooltip {
@@ -1342,16 +1342,18 @@ input[type="checkbox"]:disabled + label {
 
 .tooltip:hover::after {
     position: absolute;
-    font-size: small;
+    font-size: 0.7em;
     text-align: center;
-    background: rgba(0, 0, 0, 0.7);
-    border-radius: 5px;
+    background-color: #0095dd;
+    opacity: 0.85;
+    border-radius: 4px;
     bottom: 26px;
     color: #fff;
     content: attr(data-title);
     right: 20%;
-    padding: 4px 10px;
+    padding: 0.5em;
     z-index: 98;
+    transition: all linear .1s;
 }
 
 /* Unlocalized words view */

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -793,8 +793,8 @@ input[type="checkbox"]:disabled + label {
     display: block;
     white-space: normal;
     font-size: 0.9em;
-    top: 20px;
-    left: 20px;
+    top: 25px;
+    left: -80px;
     width: 200px;
     padding: 0.5em;
     text-align: center;
@@ -802,7 +802,7 @@ input[type="checkbox"]:disabled + label {
     border-radius: 4px;
     background-color: #0095dd;
     transition: all linear .1s;
-    opacity: 0.9;
+    opacity: 0.75;
 }
 
 .search_tooltip {

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -772,6 +772,7 @@ input[type="checkbox"]:disabled + label {
     display: block;
     float: left;
     width: 115px;
+    position: relative;
 }
 
 #simplesearchform {
@@ -786,6 +787,30 @@ input[type="checkbox"]:disabled + label {
 
 #simplesearchform #product_select {
     width: 150px;
+}
+
+#advanced_search span > label:hover + .search_tooltip {
+    display: block;
+    white-space: normal;
+    top: -5px;
+    left: 0;
+    width: 200px;
+    font-size: 1.05em;
+    padding: 0.5em;
+    text-align: center;
+    color: #fff;
+    border-radius: 4px;
+    background-color: #0095dd;
+    transition: all 0.3s cubic-bezier(0.3, 0, 0, 1);
+    transform: rotateX(20deg) scale(0.8);
+    transform-origin: center 120%;
+    opacity: 0.9;
+}
+
+.search_tooltip {
+    display: none;
+    position: absolute;
+    z-index: 2;
 }
 
 /* Autocomplete styles for suggestion popup */

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -792,6 +792,7 @@ input[type="checkbox"]:disabled + label {
 #advanced_search span > label:hover + .search_tooltip {
     display: block;
     white-space: normal;
+    font-size: 0.9em;
     top: 20px;
     left: 20px;
     width: 200px;

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -792,18 +792,15 @@ input[type="checkbox"]:disabled + label {
 #advanced_search span > label:hover + .search_tooltip {
     display: block;
     white-space: normal;
-    top: -5px;
-    left: 0;
+    top: 20px;
+    left: 20px;
     width: 200px;
-    font-size: 1.1em;
     padding: 0.5em;
     text-align: center;
     color: #fff;
     border-radius: 4px;
     background-color: #0095dd;
-    transition: all 0.3s cubic-bezier(0.3, 0, 0, 1);
-    transform: rotateX(20deg) scale(0.8);
-    transform-origin: center 120%;
+    transition: all linear .1s;
     opacity: 0.9;
 }
 

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -795,7 +795,7 @@ input[type="checkbox"]:disabled + label {
     top: -5px;
     left: 0;
     width: 200px;
-    font-size: 1.05em;
+    font-size: 1.1em;
     padding: 0.5em;
     text-align: center;
     color: #fff;

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -1183,6 +1183,7 @@ input[type="checkbox"]:disabled + label {
 
     #footer {
         font-size: 0.8em;
+        line-height: 1em;
     }
 
     #links-top-button {
@@ -1272,9 +1273,19 @@ input[type="checkbox"]:disabled + label {
         background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path style="fill: rgb(51,51,51)" d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99h-3zM9 3L5 6.99h3V14h2V6.99h3L9 3z"/></svg>') center no-repeat transparent;
     }
 
-
     #main_search fieldset#locale_switch img {
         display: block;
+    }
+
+    #advanced_search span > label:hover + .search_tooltip {
+        left: 20px;
+        top: 20px;
+        opacity: 0.9;
+    }
+
+    #advanced_search span > label:hover + #tooltip_entirewords,
+    #advanced_search span > label:hover + #tooltip_eachword {
+        left: -0px;
     }
 
     /* Hide search options */


### PR DESCRIPTION
* Stop splitting words in a sentence by default when searching
* Add "Each Word" option to search all word in a sentence (old default behavior)
* Rename "Perfect march" to "Entire string", "Whole Words" to "Entire Words"
* Reword and reverse API promotion links
* Ignore words shorter than 2 characters when searching for each word
* Added tooltips to search options

Fixes #831