### PR TITLE
Fix CSS on iOS & Safari

### DIFF
--- a/web/img/check.svg
+++ b/web/img/check.svg
@@ -1,25 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="21" height="21" viewBox="0 0 21 21">
-  <style>
-    use:not(:target) {
-      display: none;
-    }
-    use {
-      fill: #2292d0;
-    }
-    use[id$="-inverted"] {
-      fill: #fff;
-      stroke: #0095dd;
-      stroke-width: 0.5;
-    }
-    use[id$="-native"] {
-      fill: -moz-dialogText;
-    }
-  </style>
-  <defs style="display: none;">
-    <path id="check-shape" d="M 9.39,16.5 16.28,6 14.77,4.5 9.37,12.7 6.28,9.2 4.7,10.7 z"/>
-  </defs>
-  <use id="check" xlink:href="#check-shape"/>
-  <use id="check-inverted" xlink:href="#check-shape"/>
-  <use id="check-native" xlink:href="#check-shape"/>
+  <path style="fill: #2292d0;" d="M 9.39,16.5 16.28,6 14.77,4.5 9.37,12.7 6.28,9.2 4.7,10.7 z"/>
 </svg>

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -559,6 +559,7 @@ input[type='submit'] {
     border: none;
     cursor: pointer;
     text-transform: uppercase;
+    -webkit-appearance: none;
 }
 
 .button:hover,
@@ -607,6 +608,7 @@ input[type="checkbox"] + label:before {
     border: 1px solid #c1c1c1;
     margin: -2px 7px 0 0;
     background-color: #f1f1f1;
+    background-size: 16px;
     background-image: linear-gradient(#fff, rgba(255, 255, 255, 0.8));
     background-position: center center;
     background-repeat: no-repeat;
@@ -619,7 +621,7 @@ input[type="checkbox"]:not(:disabled) + label:hover::before {
 }
 
 input[type="checkbox"]:checked + label:before {
-    background-image: url(/img/check.svg#check), linear-gradient(#fff, rgba(255, 255, 255, 0.8));
+    background-image: url(/img/check.svg), linear-gradient(#fff, rgba(255, 255, 255, 0.8));
 }
 
 input[type="checkbox"]:disabled + label:before {


### PR DESCRIPTION

- Checkbox couldn’t be checked (check.svg not displayed)
- Submit buttons were looking weird:
![img_0049](https://cloud.githubusercontent.com/assets/1294206/21984055/fc1c0e10-dbeb-11e6-9726-6b2b09783588.JPG)

Also getting a bit more padding inside the checkbox for everyone, looks better and feels a bit more consistent with the original one in Firefox preferences.