### PR TITLE
Replace @@missing@@ when source is missing

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -394,7 +394,9 @@ class ShowResults
             $meta_source = $meta_target = $meta_target2 = '';
 
             // If there is no source_string, display an error, otherwise display the string + meta links
-            if (! $source_string) {
+            if ($source_string == '@@missing@@') {
+                $source_string = '<em class="error">Warning: Source string is missing</em>';
+            } elseif (! $source_string) {
                 $source_string = '<em class="error">Warning: Source string is empty</em>';
             } else {
                 $meta_source = "

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -134,7 +134,9 @@ foreach ($entities as $entity) {
     $error_message = ShowResults::buildErrorString($source_string, $target_string);
 
     // If there is no source_string, display an error, otherwise display the string + meta links
-    if (! $source_string) {
+    if ($source_string == '@@missing@@') {
+        $source_string = '<em class="error">Warning: Source string is missing</em>';
+    } elseif (! $source_string) {
         $source_string = '<em class="error">Warning: Source string is empty</em>';
     } else {
         $meta_source = "


### PR DESCRIPTION
Looks like there is another case we were not covering: https://transvision.mozfr.org/?recherche=Firefox+OS&repo=mozilla_org&sourcelocale=en-GB&locale=fr&search_type=strings&whole_word=whole_word#mozilla_org_firefox_os_tv.lang_9bf38c70

I wasn’t able to find a query where source is missing in entities results page, but made the change in results_entities.php anyway, just to be sure we’re covering the case