### PR TITLE
Track webcompat-reporter for Desktop

### DIFF
--- a/app/classes/Transvision/VersionControl.php
+++ b/app/classes/Transvision/VersionControl.php
@@ -82,6 +82,7 @@ class VersionControl
             'browser/branding/nightly/',
             'browser/branding/official/',
             'browser/branding/unofficial/',
+            'browser/extensions/webcompat-reporter/',
             'calendar/',
             'chat/',
             'devtools/client/',

--- a/app/config/list_rep_mozilla-central.txt
+++ b/app/config/list_rep_mozilla-central.txt
@@ -5,6 +5,7 @@
 ./browser/branding/nightly/locales/en-US
 ./browser/branding/official/locales/en-US
 ./browser/branding/unofficial/locales/en-US
+./browser/extensions/webcompat-reporter/locales/en-US
 ./browser/locales/en-US
 ./devtools/client/locales/en-US
 ./devtools/shared/locales/en-US


### PR DESCRIPTION
Nothing critical, tracking the newly added folder. Do you think we *need* to wait for it to ride the trains, or it’s ok to merge during this cycle?