### PR TITLE
Make the “l10n” view easier to discover - fixes #839

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -465,8 +465,8 @@ class ShowResults
                 <tr class='{$component}'>
                   <td>
                     <span class='celltitle'>Entity</span>
-                    <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
-                    <a class='l10n tag' href='/string/?entity={$key}&amp;repo={$current_repo}' title='List all translations for this entity'>l10n</a>
+                    <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>#</a>
+                    <a class='l10n tag' href='/string/?entity={$key}&amp;repo={$current_repo}' title='List all translations for this entity'>all locales</a>
                     <span class='link_to_entity'>
                       <a href=\"/{$entity_link}\">{$result_entity}</a>
                     </span>

--- a/app/views/empty_strings.php
+++ b/app/views/empty_strings.php
@@ -95,8 +95,8 @@ if (count($empty_strings) == 0) {
             <tr class='{$component}'>
               <td>
                 <span class='celltitle'>Entity</span>
-                <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this string'>link</a>
-                <a class='l10n tag' href='/string/?entity={$key}&amp;repo={$repo}' title='List all translations for this entity'>l10n</a>
+                <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this string'>#</a>
+                <a class='l10n tag' href='/string/?entity={$key}&amp;repo={$repo}' title='List all translations for this entity'>all locales</a>
                 <span class='link_to_entity'>
                   <a href=\"/{$entity_link}\">{$entity}</a>
                 </span>

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -167,8 +167,8 @@ foreach ($entities as $entity) {
   <tr>
     <td>
       <span class='celltitle'>Entity</span>
-      <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>link</a>
-      <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$current_repo}' title='List all translations for this entity'>l10n</a>
+      <a class='resultpermalink tag' id='{$anchor_name}' href='#{$anchor_name}' title='Permalink to this result'>#</a>
+      <a class='l10n tag' href='/string/?entity={$entity}&amp;repo={$current_repo}' title='List all translations for this entity'>all locales</a>
       <span class='link_to_entity'>
         <a href='/{$entity_link}'>" . ShowResults::formatEntity($entity, $search->getSearchTerms()) . "</a>
       </span>


### PR DESCRIPTION
I guess we can try this then iterate if we have better ideas. I didn’t move the link next to `<source>`, because I think it’s misleading:  `<source>` and the other links are all related/pointing to the translation, while this link is related to the entity