### PR TITLE
Add Pontoon links to QA views, improve accesskeys view

### DIFF
--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -240,6 +240,7 @@ class ShowResults
     /**
      * Return link to edit a message on external tool used by requested locale
      *
+     * @param string $tool   Tool name
      * @param string $repo   Repository
      * @param string $key    Key of the current string
      * @param string $text   Text of the current strings
@@ -247,8 +248,13 @@ class ShowResults
      *
      * @return string HTML link to edit the string inside the tool used by this locale
      */
-    public static function getEditLink($repo, $key, $text, $locale)
+    public static function getEditLink($tool, $repo, $key, $text, $locale)
     {
+        // Return if it's not a supported tool
+        if (! in_array($tool, ['pontoon'])) {
+            return '';
+        }
+
         $component = explode('/', $key)[0];
         $fileAndRawString = explode(':', $key);
 
@@ -414,7 +420,7 @@ class ShowResults
             $transliterate = $locale2 == 'sr' && ! $extra_locale && $target_string && $target_string != '@@missing@@';
 
             $edit_link = $toolUsedByTargetLocale != ''
-                ? self::getEditLink($current_repo, $key, $target_string, $locale2)
+                ? self::getEditLink($toolUsedByTargetLocale, $current_repo, $key, $target_string, $locale2)
                 : '';
 
             if ($transliterate) {

--- a/app/classes/Transvision/Utils.php
+++ b/app/classes/Transvision/Utils.php
@@ -83,52 +83,6 @@ class Utils
     }
 
     /**
-     * Print a simple table, used in the accesskeys view, needs rework
-     *
-     * @param array  $arr      First column of data
-     * @param array  $arr2     Optional. A second column of data
-     * @param array  $titles   Column titles, by default 4 columns
-     * @param string $cssclass optional css class to apply to the table
-     *
-     * @return void
-     */
-    public static function printSimpleTable(
-        $arr,
-        $arr2 = false,
-        $titles = ['Column1', 'Column2', 'Column3', 'Column4'],
-        $cssclass = ''
-    ) {
-        if ($cssclass != '') {
-            echo "<table class='{$cssclass}'>";
-        } else {
-            echo '<table>';
-        }
-        echo "<thead>\n  <tr class='column_headers'>\n" .
-             "    <th>{$titles[0]}</th><th>{$titles[1]}</th>\n";
-
-        if ($arr2) {
-            echo "    <th>{$titles[2]}</th><th>{$titles[3]}</th>\n";
-        }
-
-        echo "  </tr>\n</thead>\n<tbody>\n";
-
-        foreach ($arr as $key => $val) {
-            echo '<tr>';
-            if ($arr2) {
-                echo "<td><span class='celltitle'>{$titles[0]}</span><div class='string'>" . ShowResults::formatEntity($val) . '</div></td>';
-                echo "<td><span class='celltitle'>{$titles[1]}</span><div class='string'>" . $arr2[$val] . '</div></td>';
-                echo "<td><span class='celltitle'>{$titles[2]}</span><div class='string'>" . str_replace(' ', '<span class="highlight-red"> </span>', $arr2[$key]) . '</div></td>';
-                echo "<td><span class='celltitle'>{$titles[3]}</span><div class='string'>" . ShowResults::formatEntity($key) . '</div></td>';
-            } else {
-                echo "<td>{$key}</td>";
-                echo "<td>{$val}</td>";
-            }
-            echo '</tr>';
-        }
-        echo "</tbody>\n</table>\n";
-    }
-
-    /**
      * Split a sentence in words from longest to shortest, ignoring
      * words shorter than 2 characters.
      *

--- a/app/controllers/accesskeys.php
+++ b/app/controllers/accesskeys.php
@@ -1,0 +1,8 @@
+<?php
+namespace Transvision;
+
+// Get requested repo and locale
+require_once INC . 'l10n-init.php';
+
+include MODELS . 'accesskeys.php';
+include VIEWS . 'accesskeys.php';

--- a/app/inc/dispatcher.php
+++ b/app/inc/dispatcher.php
@@ -38,6 +38,7 @@ switch ($url['path']) {
         $controller = 'accesskeys';
         $page_title = 'Access Keys';
         $page_descr = 'Check your access keys.';
+        $js_files[] = '/js/component_filter.js';
         $js_files[] = '/js/sorttable.js';
         break;
     case Strings::StartsWith($url['path'], 'api'):

--- a/app/inc/dispatcher.php
+++ b/app/inc/dispatcher.php
@@ -35,7 +35,7 @@ switch ($url['path']) {
         $js_files[] = '/assets/jQuery-Autocomplete/dist/jquery.autocomplete.min.js';
         break;
     case 'accesskeys':
-        $view = 'accesskeys';
+        $controller = 'accesskeys';
         $page_title = 'Access Keys';
         $page_descr = 'Check your access keys.';
         $js_files[] = '/js/sorttable.js';

--- a/app/models/accesskeys.php
+++ b/app/models/accesskeys.php
@@ -1,0 +1,79 @@
+<?php
+namespace Transvision;
+
+$error_messages = [];
+$reference_locale = Project::getReferenceLocale($repo);
+$supported_locales = Project::getRepositoryLocales($repo, [$reference_locale]);
+// If the requested locale is not available, fall back to the first
+if (! in_array($locale, $supported_locales)) {
+    $locale = array_shift($supported_locales);
+}
+// Build the target locale switcher
+$target_locales_list = Utils::getHtmlSelectOptions($supported_locales, $locale);
+
+/*
+    Only use desktop repositories. If the requested repository is not
+    available, fall back to the first key.
+*/
+$channels = array_intersect_key(
+    Project::getSupportedRepositories(),
+    array_flip($desktop_repos)
+);
+if (! isset($channels[$repo])) {
+    $repo = current(array_keys($channels));
+    $error_messages[] = "The selected repository is not supported. Falling back to <em>{$repo}</em>.";
+}
+$channel_selector = Utils::getHtmlSelectOptions($channels, $repo, true);
+
+// Get strings
+$source = Utils::getRepoStrings($reference_locale, $repo);
+$target = Utils::getRepoStrings($locale, $repo);
+
+// Get strings with 'accesskey' in the string ID
+$ak_string_ids = array_filter(
+    array_keys($target),
+    function ($entity) {
+        return strpos($entity, 'accesskey') !== false;
+    }
+);
+
+// Possible labels associated to an access key
+$ak_labels = ['label', 'title', 'message'];
+
+$ak_results = [];
+foreach ($ak_string_ids as $ak_string_id) {
+    foreach ($ak_labels as $ak_label) {
+        $entity = str_replace('accesskey', $ak_label, $ak_string_id);
+        $current_ak = $target[$ak_string_id];
+
+        /*
+            Ignore:
+            * Strings not available or empty in target locale.
+            * Empty access keys in source locale.
+        */
+        if (isset($target[$entity]) && ! empty($target[$entity]) && ! empty($source[$ak_string_id]) ) {
+            /*
+                Store the string if the access key is empty or using a
+                character not available in the label.
+            */
+            if ($current_ak == '') {
+                $ak_results[$ak_string_id] = $entity;
+            } elseif (mb_stripos($target[$entity], $current_ak) === false) {
+                $ak_results[$ak_string_id] = $entity;
+            }
+        }
+    }
+}
+
+// Add component filter
+if (in_array($repo, $desktop_repos)) {
+    // Build logic to filter components
+    $components = Project::getComponents(array_flip($ak_results));
+    $filter_block = '';
+    foreach ($components as $value) {
+        $filter_block .= " <a href='#{$value}' id='{$value}' class='filter'>{$value}</a>";
+    }
+}
+
+// RTL support
+$direction = RTLSupport::getDirection($locale);

--- a/app/models/accesskeys.php
+++ b/app/models/accesskeys.php
@@ -73,9 +73,7 @@ foreach ($ak_string_ids as $ak_string_id) {
                 Store the string if the access key is empty or using a
                 character not available in the label.
             */
-            if ($current_ak == '') {
-                $ak_results[$ak_string_id] = $entity;
-            } elseif (mb_stripos($target[$entity], $current_ak) === false) {
+            if (($current_ak == '') || (mb_stripos($target[$entity], $current_ak) === false)) {
                 $ak_results[$ak_string_id] = $entity;
             }
         }

--- a/app/views/accesskeys.php
+++ b/app/views/accesskeys.php
@@ -1,63 +1,109 @@
 <?php
 namespace Transvision;
 
-require_once INC . 'l10n-init.php';
-
-$strings[$repo] = Utils::getRepoStrings($locale, $repo);
-$strings_english[$repo] = Utils::getRepoStrings('en-US', $repo);
-
-$channel_selector = Utils::getHtmlSelectOptions(
-    array_intersect_key(
-        $repos_nice_names,
-        array_flip($desktop_repos)
-    ),
-    $repo,
-    true
-);
-
-// Get the locale list
-$loc_list = Project::getRepositoryLocales($repo);
-
-// Build the target locale switcher
-$target_locales_list = Utils::getHtmlSelectOptions($loc_list, $locale);
-
-$akeys = array_filter(
-    array_keys($strings[$repo]),
-    function ($entity) {
-        return substr($entity, -9) == 'accesskey';
-    }
-);
-
-$ak_labels = ['.label', '.title', '.title2'];
-$ak_results = [];
-
-foreach ($akeys as $akey) {
-    $entity = substr($akey, 0, -10);
-    $akey_value = $strings[$repo][$akey];
-
-    foreach ($ak_labels as $ak_label) {
-        if (isset($strings[$repo][$entity . $ak_label])
-             && !empty($strings[$repo][$entity . $ak_label])
-             && isset($strings_english[$repo][$akey])
-             && !empty($strings_english[$repo][$akey])
-            ) {
-            if ($akey_value == '') {
-                $ak_results[$akey] = $entity . $ak_label;
-            } elseif (mb_stripos($strings[$repo][$entity . $ak_label], $akey_value) === false) {
-                $ak_results[$akey] = $entity . $ak_label;
-            } else {
-                break;
-            }
-        }
-    }
-}
 // Include the common simple search form
 include __DIR__ . '/simplesearchform.php';
 
-echo '<h2>' . count($ak_results) . ' potential accesskey errors</h2>';
-Utils::printSimpleTable(
-    $ak_results,
-    $strings[$repo],
-    ['Label entity', 'Label value', 'Access&nbsp;key', 'Access key entity'],
-    'collapsable sortable'
-);
+if (! empty($ak_results)) {
+    $search_id = 'accesskeys';
+    $content = '';
+    if (! empty($error_messages)) {
+        $content .= '<p class="error">' .
+            implode('<br/>', $error_messages) .
+            '</p>';
+    }
+    $content .= "<h2><span class=\"results_count_{$search_id}\">"
+        . Utils::pluralize(count($ak_results), 'potential access key error')
+        . "</span> found</h2>\n";
+
+    if (isset($filter_block)) {
+        $content .= "<div id='filters'>" .
+                    "  <h4>Filter by folder:</h4>\n" .
+                    "  <a href='#showall' id='showall' class='filter'>Show all results</a>\n" .
+                    $filter_block .
+                    "</div>\n";
+    }
+
+    $content .= "
+        <table class='collapsable results_table sortable {$search_id}'>
+          <thead>
+            <tr class='column_headers'>
+              <th>Entity</th>
+              <th>Label</th>
+              <th>Access&nbsp;key</th>
+              <th>Access&nbsp;key entity</th>
+            </tr>
+          </thead>
+          <tbody>\n";
+
+    // Get the tool used to edit strings for the target locale
+    $toolUsedByTargetLocale = Project::getLocaleTool($locale);
+
+    foreach ($ak_results as $ak_string => $ak_label) {
+        // Link to entity
+        $ak_link = "?sourcelocale={$reference_locale}" .
+           "&locale={$locale}" .
+           "&repo={$repo}" .
+           "&search_type=entities&recherche={$ak_string}" .
+           '&entire_string=entire_string';
+        $label_link = "?sourcelocale={$reference_locale}" .
+           "&locale={$locale}" .
+           "&repo={$repo}" .
+           "&search_type=entities&recherche={$ak_label}" .
+           '&entire_string=entire_string';
+
+        $path_ak = VersionControl::hgPath($locale, $repo, $ak_string);
+        $path_label = VersionControl::hgPath($locale, $repo, $ak_label);
+
+        $edit_link_ak = $toolUsedByTargetLocale != ''
+            ? ShowResults::getEditLink($toolUsedByTargetLocale, $repo, $ak_string, $target[$ak_string], $locale)
+            : '';
+        $edit_link_label = $toolUsedByTargetLocale != ''
+            ? ShowResults::getEditLink($toolUsedByTargetLocale, $repo, $ak_label, $target[$ak_label], $locale)
+            : '';
+
+        $ak_value = ! empty($target[$ak_string])
+            ? Utils::secureText($target[$ak_string])
+            : '<em class="error">(empty)</em>';
+        $label_value = ! empty($target[$ak_label])
+            ? Utils::secureText($target[$ak_label])
+            : '<em class="error">(empty)</em>';
+
+        $component = explode('/', $ak_string)[0];
+        $content .= "<tr class='{$component} {$search_id}'>
+                       <td>
+                          <span class='celltitle'>Entity</span>
+                          <span class='link_to_entity'>
+                            <a href=\"/{$label_link}\">" . ShowResults::formatEntity($ak_label) . "</a>
+                          </span>
+                       </td>
+                       <td dir='{$direction}'>
+                          <span class='celltitle'>Label</span>
+                          <div class='string'>{$label_value}</div>
+                          <div class='result_meta_link'>
+                            <a class='source_link' href='{$path_label}'>&lt;source&gt;</a>
+                            {$edit_link_label}
+                          </div>
+                       </td>
+                       <td dir='{$direction}'>
+                          <span class='celltitle'>Access&nbsp;key</span>
+                          <div class='string'>{$ak_value}</div>
+                          <div class='result_meta_link'>
+                            <a class='source_link' href='{$path_ak}'>&lt;source&gt;</a>
+                            {$edit_link_ak}
+                          </div>
+                       </td>
+                       <td>
+                          <span class='celltitle'>Access&nbsp;key entity</span>
+                          <span class='link_to_entity'>
+                            <a href=\"/{$ak_link}\">" . ShowResults::formatEntity($ak_string) . "</a>
+                          </span>
+                       </td>
+                     </tr>\n";
+    }
+    $content .= "</tbody>\n</table>\n";
+} else {
+    $content = '<h2>Congratulations, no errors found.</h2>';
+}
+
+print $content;

--- a/app/views/accesskeys.php
+++ b/app/views/accesskeys.php
@@ -80,7 +80,7 @@ if (! empty($ak_results)) {
                        <td dir='{$direction}'>
                           <span class='celltitle'>Label</span>
                           <div class='string'>{$label_value}</div>
-                          <div class='result_meta_link'>
+                          <div dir='ltr' class='result_meta_link'>
                             <a class='source_link' href='{$path_label}'>&lt;source&gt;</a>
                             {$edit_link_label}
                           </div>
@@ -88,7 +88,7 @@ if (! empty($ak_results)) {
                        <td dir='{$direction}'>
                           <span class='celltitle'>Access&nbsp;key</span>
                           <div class='string'>{$ak_value}</div>
-                          <div class='result_meta_link'>
+                          <div dir='ltr' class='result_meta_link'>
                             <a class='source_link' href='{$path_ak}'>&lt;source&gt;</a>
                             {$edit_link_ak}
                           </div>

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -29,6 +29,9 @@ if ($error_count > 0) {
           </thead>
           <tbody>\n";
 
+    // Get the tool used to edit strings for the target locale
+    $toolUsedByTargetLocale = Project::getLocaleTool($locale);
+
     foreach ($var_errors as $string_id) {
         // Link to entity
         $string_id_link = "?sourcelocale={$source_locale}" .
@@ -41,8 +44,11 @@ if ($error_count > 0) {
             $target[$string_id], $repo, $string_id_link
         );
 
-        $path_locale1 = VersionControl::hgPath($source_locale, $repo, $string_id);
-        $path_locale2 = VersionControl::hgPath($locale, $repo, $string_id);
+        $path_source_locale = VersionControl::hgPath($source_locale, $repo, $string_id);
+        $path_target_locale = VersionControl::hgPath($locale, $repo, $string_id);
+        $edit_link = $toolUsedByTargetLocale != ''
+            ? ShowResults::getEditLink($repo, $string_id, $target[$string_id], $locale)
+            : '';
 
         $component = explode('/', $string_id)[0];
         $content .= "<tr class='{$component} {$search_id}'>
@@ -56,14 +62,15 @@ if ($error_count > 0) {
                           <span class='celltitle'>{$source_locale}</span>
                           <div class='string'>" . Utils::secureText($source[$string_id]) . "</div>
                           <div class='result_meta_link'>
-                            <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
+                            <a class='source_link' href='{$path_source_locale}'>&lt;source&gt;</a>
                           </div>
                        </td>
                         <td dir='{$direction2}'>
                           <span class='celltitle'>$locale</span>
                           <div class='string'>" . Utils::secureText($target[$string_id]) . "</div>
                           <div class='result_meta_link'>
-                            <a class='source_link' href='{$path_locale2}'>&lt;source&gt;</a>
+                            <a class='source_link' href='{$path_target_locale}'>&lt;source&gt;</a>
+                            {$edit_link}
                             <a class='bug_link' target='_blank' href='{$bugzilla_link}'>&lt;report a bug&gt;</a>
                           </div>
                        </td>

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -61,14 +61,14 @@ if ($error_count > 0) {
                        <td dir='{$direction1}'>
                           <span class='celltitle'>{$source_locale}</span>
                           <div class='string'>" . Utils::secureText($source[$string_id]) . "</div>
-                          <div class='result_meta_link'>
+                          <div dir='ltr' class='result_meta_link'>
                             <a class='source_link' href='{$path_source_locale}'>&lt;source&gt;</a>
                           </div>
                        </td>
                         <td dir='{$direction2}'>
                           <span class='celltitle'>$locale</span>
                           <div class='string'>" . Utils::secureText($target[$string_id]) . "</div>
-                          <div class='result_meta_link'>
+                          <div dir='ltr' class='result_meta_link'>
                             <a class='source_link' href='{$path_target_locale}'>&lt;source&gt;</a>
                             {$edit_link}
                             <a class='bug_link' target='_blank' href='{$bugzilla_link}'>&lt;report a bug&gt;</a>

--- a/app/views/check_variables.php
+++ b/app/views/check_variables.php
@@ -47,7 +47,7 @@ if ($error_count > 0) {
         $path_source_locale = VersionControl::hgPath($source_locale, $repo, $string_id);
         $path_target_locale = VersionControl::hgPath($locale, $repo, $string_id);
         $edit_link = $toolUsedByTargetLocale != ''
-            ? ShowResults::getEditLink($repo, $string_id, $target[$string_id], $locale)
+            ? ShowResults::getEditLink($toolUsedByTargetLocale, $repo, $string_id, $target[$string_id], $locale)
             : '';
 
         $component = explode('/', $string_id)[0];

--- a/app/views/empty_strings.php
+++ b/app/views/empty_strings.php
@@ -50,6 +50,9 @@ if (count($empty_strings) == 0) {
     echo '<div class="message"><p>No strings found.</p></div>';
 } else {
     $text_direction = RTLSupport::getDirection($locale);
+    // Get the tool used to edit strings for the target locale
+    $toolUsedByTargetLocale = Project::getLocaleTool($locale);
+
     $table = "<table class='collapsable results_table sortable'>
                  <thead>
                    <tr class='column_headers'>
@@ -67,10 +70,14 @@ if (count($empty_strings) == 0) {
         $locale_string = Strings::highlightSpecial(htmlspecialchars($strings['translation']), false);
 
         $entity_link = "?sourcelocale={$reference_locale}"
-        . "&locale={$locale}"
-        . "&repo={$repo}"
-        . "&search_type=entities&recherche={$key}"
-        . '&entire_string=entire_string';
+            . "&locale={$locale}"
+            . "&repo={$repo}"
+            . "&search_type=entities&recherche={$key}"
+            . '&entire_string=entire_string';
+
+        $edit_link = $toolUsedByTargetLocale != ''
+            ? ShowResults::getEditLink($toolUsedByTargetLocale, $repo, $key, $strings['translation'], $locale)
+            : '';
 
         $bugzilla_link = [Bugzilla::reportErrorLink(
             $locale, $key, $reference_string, $locale_string, $repo, $entity_link
@@ -119,6 +126,7 @@ if (count($empty_strings) == 0) {
                   <a class='source_link' href='{$locale_path}'>
                     &lt;source&gt;
                   </a>
+                  {$edit_link}
                   &nbsp;
                   <a class='bug_link' target='_blank' href='{$bugzilla_link[0]}'>
                     &lt;report a bug&gt;

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -167,7 +167,7 @@ foreach ($entities as $entity) {
     $toolUsedByTargetLocale = Project::getLocaleTool($locale);
 
     $edit_link = $toolUsedByTargetLocale != ''
-        ? ShowResults::getEditLink($current_repo, $entity, $target_string, $locale)
+        ? ShowResults::getEditLink($toolUsedByTargetLocale, $current_repo, $entity, $target_string, $locale)
         : '';
 
     $table .= "

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -349,6 +349,7 @@ class ShowResults extends atoum\test
         return [
             // Pontoon links
             [
+                'pontoon',
                 'central',
                 'browser/chrome/browser/browser.properties:webextPerms.hostDescription.allUrls',
                 'test',
@@ -356,6 +357,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/fr/firefox/browser/chrome/browser/browser.properties?search=webextPerms.hostDescription.allUrls'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'calendar/chrome/calendar/calendar.dtd:calendar.calendar.label',
                 'test',
@@ -363,6 +365,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/fr/lightning/calendar/chrome/calendar/calendar.dtd?search=calendar.calendar.label'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'chat/commands.properties:dnd',
                 'test',
@@ -370,6 +373,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/fr/thunderbird/chat/commands.properties?search=dnd'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'editor/ui/chrome/composer/editingOverlay.dtd:fileRecentMenu.label',
                 'test',
@@ -377,6 +381,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/fr/thunderbird/editor/ui/chrome/composer/editingOverlay.dtd?search=fileRecentMenu.label'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'extensions/irc/chrome/about.dtd:chatzilla.label',
                 'test',
@@ -384,6 +389,7 @@ class ShowResults extends atoum\test
                 '',
             ],
             [
+                'pontoon',
                 'central',
                 'mail/chrome/messenger/addressbook/abContactsPanel.dtd:ccButton.label',
                 'test',
@@ -391,6 +397,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/de/thunderbird/mail/chrome/messenger/addressbook/abContactsPanel.dtd?search=ccButton.label'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'mobile/android/base/android_strings.dtd:activity_stream_highlights',
                 'test',
@@ -398,6 +405,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/bg/firefox-for-android/mobile/android/base/android_strings.dtd?search=activity_stream_highlights'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'central',
                 'suite/chrome/browser/taskbar.properties:taskbar.tasks.composeMessage.description',
                 'test',
@@ -405,6 +413,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/it/seamonkey/suite/chrome/browser/taskbar.properties?search=taskbar.tasks.composeMessage.description'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'beta',
                 'suite/chrome/browser/taskbar.properties:taskbar.tasks.composeMessage.description',
                 'test',
@@ -412,6 +421,7 @@ class ShowResults extends atoum\test
                 '',
             ],
             [
+                'pontoon',
                 'release',
                 'suite/chrome/browser/taskbar.properties:taskbar.tasks.composeMessage.description',
                 'test',
@@ -419,6 +429,7 @@ class ShowResults extends atoum\test
                 '',
             ],
             [
+                'pontoon',
                 'mozilla_org',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 'test',
@@ -426,6 +437,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/it/mozillaorg/firefox/android/index.lang?search=test'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'firefox_ios',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 'test',
@@ -433,6 +445,7 @@ class ShowResults extends atoum\test
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/it/firefox-for-ios/firefox-ios.xliff?search=test'>&lt;edit in Pontoon&gt;</a>",
             ],
             [
+                'pontoon',
                 'firefox_ios',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 '@@missing@@',
@@ -440,6 +453,7 @@ class ShowResults extends atoum\test
                 '',
             ],
             [
+                'pontoon',
                 'firefox_ios',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 '<em class="error">Warning: Missing string</em>',
@@ -448,11 +462,21 @@ class ShowResults extends atoum\test
             ],
             // Test URLencode
             [
+                'pontoon',
                 'firefox_ios',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 '%(test)',
                 'it',
                 "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/it/firefox-for-ios/firefox-ios.xliff?search=%25%28test%29'>&lt;edit in Pontoon&gt;</a>",
+            ],
+            // Test unknown tool
+            [
+                'pontoon.test',
+                'firefox_ios',
+                'mozilla_org/firefox/android/index.lang:4e0bc9d4',
+                '%(test)',
+                'it',
+                '',
             ],
         ];
     }
@@ -460,11 +484,11 @@ class ShowResults extends atoum\test
     /**
      * @dataProvider getEditLinkDP
      */
-    public function testGetEditLink($a, $b, $c, $d, $e)
+    public function testGetEditLink($a, $b, $c, $d, $e, $f)
     {
         $obj = new _ShowResults();
         $this
-            ->string($obj->getEditLink($a, $b, $c, $d))
-                ->isEqualTo($e);
+            ->string($obj->getEditLink($a, $b, $c, $d, $e))
+                ->isEqualTo($f);
     }
 }

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -1061,6 +1061,14 @@ input[type="checkbox"]:disabled + label {
     margin-top: -10px;
 }
 
+/* Access keys view */
+#keys .error {
+    margin: 0 auto;
+    text-align: center;
+    width: 75%;
+    color: #ed3860;
+}
+
 /* Empty strings view */
 #empty_strings .intro,
 #empty_strings .message {
@@ -1136,6 +1144,12 @@ input[type="checkbox"]:disabled + label {
 
     table.collapsable th {
         display: none;
+    }
+
+    table.collapsable tr {
+        float: left;
+        width: 100%;
+        padding: 3px;
     }
 
     table.collapsable td {


### PR DESCRIPTION
Fixes #870 and #883. It's a first draft (seems to be working), but not ready for review yet.

The change to getEditLink is needed because I added a pontoon-mozorg to mozilla-l10n-query yesterday (for the webdashboard), since we have locales using Pontoon for mozilla.org but not for products (e.g. it, da, de, etc.).

Result: now we're showing Pontoon links to every locale.