### PR TITLE
(fix #907) Trim query when searching for entities

### DIFF
--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -68,12 +68,12 @@ if ($check['t2t']) {
     require_once VIEWS . 'results_glossary.php';
 } else {
     // No search
-    if ($my_search == '') {
+    if ($search->getSearchTerms() == '') {
         return;
     }
 
     // Search not acceptable
-    if (mb_strlen(trim($my_search)) < 2) {
+    if (mb_strlen($search->getSearchTerms()) < 2) {
         print '<p><strong>Search term should be at least 2 characters long.</strong></p>';
 
         return;

--- a/app/controllers/mainsearch.php
+++ b/app/controllers/mainsearch.php
@@ -54,6 +54,17 @@ if ($url['path'] == '3locales') {
     require_once MODELS . '3locales_search.php';
 }
 
+/*
+    Trim the search query when searching for entities, display a warning.
+    This needs to be done before including search_form.php, in order to
+    display the trimmed value in the search field.
+*/
+if ($search->getSearchType() == 'entities' &&
+    $search->getSearchTerms() !== trim($search->getSearchTerms())) {
+    $search->setSearchTerms(trim($search->getSearchTerms()));
+    $warning_whitespaces = '<p id="search_warning"><strong>Warning:</strong> leading or trailing whitespaces have been automatically removed from the search query.</p>';
+}
+
 // The search form is shared by all search views
 require_once VIEWS . 'search_form.php';
 

--- a/app/models/mainsearch_entities.php
+++ b/app/models/mainsearch_entities.php
@@ -12,6 +12,12 @@ if ($url['path'] == '3locales') {
     $extra_column_header = '';
 }
 
+// Trim the search query when searching for entities, display a warning
+if ($search->getSearchTerms() !== trim($search->getSearchTerms())) {
+    $search->setRegexSearchTerms(trim($search->getSearchTerms()));
+    $warning_whitespaces = '<p id="search_warning"><strong>Warning:</strong> leading or trailing whitespaces have been automatically removed from the search query.</p>';
+}
+
 $entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
 
 $real_search_results = count($entities);

--- a/app/models/mainsearch_entities.php
+++ b/app/models/mainsearch_entities.php
@@ -12,12 +12,6 @@ if ($url['path'] == '3locales') {
     $extra_column_header = '';
 }
 
-// Trim the search query when searching for entities, display a warning
-if ($search->getSearchTerms() !== trim($search->getSearchTerms())) {
-    $search->setRegexSearchTerms(trim($search->getSearchTerms()));
-    $warning_whitespaces = '<p id="search_warning"><strong>Warning:</strong> leading or trailing whitespaces have been automatically removed from the search query.</p>';
-}
-
 $entities = ShowResults::searchEntities($tmx_source, $search->getRegex());
 
 $real_search_results = count($entities);

--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -62,11 +62,11 @@ foreach ($searches as $key => $value) {
             : "<span class=\"results_count_{$search_id}\">" . Utils::pluralize(count($search_results), 'result') . '</span>';
 
         $output[$key] = "<h2>Displaying {$message_count} for the string "
-                        . '<span class="searchedTerm">' . htmlentities($my_search) . "</span> in {$key}:</h2>";
+                        . '<span class="searchedTerm">' . htmlentities($search->getSearchTerms()) . "</span> in {$key}:</h2>";
         $output[$key] .= ShowResults::resultsTable($search, $search_id, $search_results, $page);
     } else {
         $output[$key] = '<h2>No matching results for the string '
-                        . '<span class="searchedTerm">' . htmlentities($my_search) . '</span>'
+                        . '<span class="searchedTerm">' . htmlentities($search->getSearchTerms()) . '</span>'
                         . " for the locale {$key}</h2>";
     }
 }

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -217,6 +217,10 @@ if (isset($filter_block)):
 <?php
 endif;
 
+if (isset($warning_whitespaces)) {
+    print $warning_whitespaces;
+}
+
 $table .= "</tbody>\n</table>\n\n";
 if ($entities) {
     $message_count = $real_search_results > $limit_results

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -225,7 +225,7 @@ $table .= "</tbody>\n</table>\n\n";
 if ($entities) {
     $message_count = $real_search_results > $limit_results
         ? "<span class=\"results_count_{$search_id}\">{$limit_results} results</span> out of {$real_search_results}"
-        : "<span class=\"results_count_{$search_id}\">" . Utils::pluralize(count($search_results), 'result') . '</span>';
+        : "<span class=\"results_count_{$search_id}\">" . Utils::pluralize(count($real_search_results), 'result') . '</span>';
     print "<h2>Display {$message_count}</h2>";
     print $table;
 }

--- a/app/views/results_similar.php
+++ b/app/views/results_similar.php
@@ -15,7 +15,7 @@ foreach ($best_matches as $match) {
 
 <div class="resultsbox">
     <h3>There were no results for the string
-    <span class="searchedTerm"><?=htmlentities($my_search)?></span>.
+    <span class="searchedTerm"><?=htmlentities($search->getSearchTerms())?></span>.
     <br>Possibly related searches:
     </h3>
 


### PR DESCRIPTION
Also clean up code, using class method instead of a variable defined in a random include.