### PR TITLE
Disable suggestions on .focus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,15 +49,15 @@
             "package": {
                 "name": "devbridge/jQuery-Autocomplete",
                 "type": "component",
-                "version": "1.4.2",
+                "version": "1.4.3",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/devbridge/jQuery-Autocomplete/archive/v1.4.2.zip"
+                    "url": "https://github.com/devbridge/jQuery-Autocomplete/archive/v1.4.3.zip"
                 },
                 "source": {
                     "type": "git",
                     "url": "https://github.com/devbridge/jQuery-Autocomplete.git",
-                    "reference": "1.4.2"
+                    "reference": "1.4.3"
                 },
                 "extra": {
                     "component": {

--- a/web/js/main_search.js
+++ b/web/js/main_search.js
@@ -45,6 +45,8 @@ $(document).ready(function() {
                     $('#searchform').submit();
                 }
             });
+            // Disable autocomplete on focus
+            $('#recherche').off('focus.autocomplete');
         }
         if ($('#search_type').val() !== 'entities') {
             $('#recherche').autocomplete().enable();


### PR DESCRIPTION
Search for something, e.g. 'test', in strings or strings+entities. If you then select "entities", suggestions are disabled (writing doesn't update them), but they keep showing up.

Tried .clear, .clearCache but none of them work. Disabling autocomplete on focus seems to solve this issue, but also suggestions randomly showing up after the viewport has scrolled.

Also updating the component in the process