### PR TITLE
Remove unnecessary exception in commandkeys view

### DIFF
--- a/app/models/commandkeys.php
+++ b/app/models/commandkeys.php
@@ -41,7 +41,6 @@ $commandkey_ids = array_filter(
 $ignored_ids = [
     'browser/chrome/browser/browser.properties:addonPostInstall.okay.key',
     'devtools/client/webconsole.properties:table.key',
-    'extensions/irc/chrome/chatzilla.properties:msg.url.key',
 ];
 $ignored_files = [
     'extensions/irc/chrome/chatzilla.properties',


### PR DESCRIPTION
The entire file is already excluded: extensions/irc/chrome/chatzilla.properties
I think I started with the single key, then added the entire file