### PR TITLE
Expose latest tag name in the footer and automatically generate a rel…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ app/config/sources/*.txt
 cache/*.cache
 cache/lastdataupdate.txt
 cache/stats_*.json
+cache/tag.txt
 cache/version.txt
 composer.lock
 composer.phar

--- a/app/inc/constants.php
+++ b/app/inc/constants.php
@@ -27,7 +27,7 @@ if (php_sapi_name() != 'cli') {
     If the file doesn't exist, or is empty, fall back to 'unknown.dev'.
 */
 if (file_exists(CACHE_PATH . 'version.txt')) {
-    $file_content = file(CACHE_PATH . 'version.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    $file_content = file(CACHE_PATH . 'version.txt');
     $git_hash = empty($file_content)
         ? 'unknown.dev'
         : $file_content[0];

--- a/app/models/changelog.php
+++ b/app/models/changelog.php
@@ -62,7 +62,7 @@ $get_sections = function ($section) {
 };
 
 // Helper to generate the list of patches for the version
-$github_link = function ($release) use ($releases) {
+$github_link = function ($release, $releases) {
     if ($release > 1) {
         $keys = array_keys($releases);
         $previous = $keys[array_search($release, $keys, true) - 1];
@@ -76,7 +76,7 @@ LINK;
 };
 
 // Helper to generate a release title block
-$release_title = function ($version) use ($releases) {
+$release_title = function ($version, $releases) {
     return <<<TITLE
 <h2 class="release_number" id="v{$version}"><a href="#v{$version}">Version {$version}
 <span class="release_date">{$releases[$version]}</span></a>
@@ -121,4 +121,21 @@ $authors = function ($list) use ($author_urls) {
     }
 
     return $text;
+};
+
+$latest_undocumented_release = function() use ($releases, $github_link, $release_title) {
+  $text = '';
+  $version_number = str_replace("\n", '', str_replace('v', '', file_get_contents(CACHE_PATH . 'tag.txt')));
+  end($releases);
+  $last_release = key($releases);
+
+  if ($version_number != $last_release) {
+    $github_relnotes = "https://github.com/mozfr/transvision/releases/tag/v{$version_number}";
+    $releases[$version_number] = 'Unknown';
+    $text .= $release_title($version_number, $releases);
+    $text .= "<p>This release is undocumented, but you can know more in the <a href=\"{$github_relnotes}\">GitHub release notes</a> and with the list of commits below since the last documented release.</p>";
+    $text .= $github_link($version_number, $releases);
+  }
+
+  return $text;
 };

--- a/app/models/changelog.php
+++ b/app/models/changelog.php
@@ -125,7 +125,7 @@ $authors = function ($list) use ($author_urls) {
 
 $latest_undocumented_release = function() use ($releases, $github_link, $release_title) {
   $text = '';
-  $version_number = str_replace("\n", '', str_replace('v', '', file_get_contents(CACHE_PATH . 'tag.txt')));
+  $version_number = substr(file_get_contents(CACHE_PATH . 'tag.txt'), 1);
   end($releases);
   $last_release = key($releases);
 
@@ -133,7 +133,7 @@ $latest_undocumented_release = function() use ($releases, $github_link, $release
     $github_relnotes = "https://github.com/mozfr/transvision/releases/tag/v{$version_number}";
     $releases[$version_number] = 'Unknown';
     $text .= $release_title($version_number, $releases);
-    $text .= "<p>This release is undocumented, but you can know more in the <a href=\"{$github_relnotes}\">GitHub release notes</a> and with the list of commits below since the last documented release.</p>";
+    $text .= "<p>There is no entry in the changelog for this release, but you can learn more about it in the <a href=\"{$github_relnotes}\">GitHub release notes</a> and look at the list of commits from the latest documented release.</p>";
     $text .= $github_link($version_number, $releases);
   }
 

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -161,16 +161,19 @@ DEV_VERSION="dev"
 if [ ! -d ${install}/.git ]
 then
     CURRENT_TIP="unknown"
+    LATEST_TAG_NAME="unknown"
 else
     cd "${install}"
     CURRENT_TIP=$(git rev-parse HEAD)
     LATEST_TAG=$(git describe --abbrev=0 --tags | xargs -I {} git rev-list -n 1 {})
+    LATEST_TAG_NAME=$(git describe --abbrev=0 --tags)
     if [ "${CURRENT_TIP}" = "${LATEST_TAG}" ]
     then
         DEV_VERSION=""
     fi
 fi
 echo "${CURRENT_TIP:0:7}${DEV_VERSION}" > "${install}/cache/version.txt"
+echo "${LATEST_TAG_NAME}" | tr -d '\n' > "${install}/cache/tag.txt"
 
 setupExternalLibraries
 initGeckoStringsRepo

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -172,7 +172,7 @@ else
         DEV_VERSION=""
     fi
 fi
-echo "${CURRENT_TIP:0:7}${DEV_VERSION}" > "${install}/cache/version.txt"
+echo "${CURRENT_TIP:0:7}${DEV_VERSION}" | tr -d '\n' > "${install}/cache/version.txt"
 echo "${LATEST_TAG_NAME}" | tr -d '\n' > "${install}/cache/tag.txt"
 
 setupExternalLibraries

--- a/app/views/changelog.php
+++ b/app/views/changelog.php
@@ -2,9 +2,10 @@
 namespace Transvision;
 
 $output = '';
+$output .= $latest_undocumented_release();
 foreach ($changelog as $release => $changes) {
     // Add release title and initialize variables
-    $output .= $release_title($release);
+    $output .= $release_title($release, $releases);
     $empty_release = true;
     $section = '';
     foreach ($changes as $change => $attributes) {
@@ -28,7 +29,7 @@ foreach ($changelog as $release => $changes) {
         $output .= "</div></li>\n";
     }
     $output .= "</ul>\n";
-    $output .= $github_link($release);
+    $output .= $github_link($release, $releases);
 }
 
 print($output);

--- a/app/views/changelog_rss.php
+++ b/app/views/changelog_rss.php
@@ -44,7 +44,7 @@ foreach ($changelog as $release => $changes) {
 
         $output .= '<br>';
     }
-    $output .= $github_link($release);
+    $output .= $github_link($release, $releases);
     $output .= ' ]]></description>' . "\n";
     $output .= '  </item>' . "\n";
 }

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -78,7 +78,7 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
 
 $version_number = '';
 if (file_exists(CACHE_PATH . 'tag.txt')) {
-    $version_number = $title_productname . ' ' . file_get_contents(CACHE_PATH . 'tag.txt') . "\n";
+    $version_number = $title_productname . ' ' . file_get_contents(CACHE_PATH . 'tag.txt');
 }
 ?>
 <!doctype html>

--- a/app/views/templates/base.php
+++ b/app/views/templates/base.php
@@ -75,6 +75,11 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
 } else {
     $last_update = "<p>Data last updated: not available.</p>\n";
 }
+
+$version_number = '';
+if (file_exists(CACHE_PATH . 'tag.txt')) {
+    $version_number = $title_productname . ' ' . file_get_contents(CACHE_PATH . 'tag.txt') . "\n";
+}
 ?>
 <!doctype html>
 
@@ -134,6 +139,7 @@ if (file_exists(CACHE_PATH . 'lastdataupdate.txt')) {
   <div id="footer">
     <p>Transvision is a tool provided by the French Mozilla community, <a href="https://www.mozfr.org" title="Home of MozFR, the French Mozilla Community" hreflang="fr">MozFR</a>.</p>
     <?= $last_update ?>
+    <?= $version_number ?>
   </div>
 
   <script src="/assets/jquery/jquery.min.js?v=<?= VERSION ?>"></script>


### PR DESCRIPTION
…ease in /news

Didn’t implement the same changes to the RSS feed, because:

1/ I think it doesn’t really make sense to publish temporary things there (it will disappear at the next documented release)
2/ I’m lazy 😇