### PR TITLE
Add known mappings for access keys in sync preferences

### DIFF
--- a/app/models/accesskeys.php
+++ b/app/models/accesskeys.php
@@ -48,8 +48,14 @@ $ignored_ids = [
 // Some keys map to a different string ID than the one identified by the
 // algorithm
 $known_mappings = [
-    'browser/chrome/browser/browser.properties:decoder.noCodecs.accesskey' => 'browser/chrome/browser/browser.properties:decoder.noCodecs.button',
-    'extensions/irc/chrome/pref-irc.dtd:pref-irc.open.accesskey'           => 'extensions/irc/chrome/pref-irc.dtd:pref-irc.open.label',
+    'browser/chrome/browser/browser.properties:decoder.noCodecs.accesskey'      => 'browser/chrome/browser/browser.properties:decoder.noCodecs.button',
+    'extensions/irc/chrome/pref-irc.dtd:pref-irc.open.accesskey'                => 'extensions/irc/chrome/pref-irc.dtd:pref-irc.open.label',
+    'browser/chrome/browser/preferences/sync.dtd:engine.tabs.accesskey'         => 'browser/chrome/browser/preferences/sync.dtd:engine.tabs.label2',
+    'browser/chrome/browser/preferences/sync.dtd:engine.logins.accesskey'       => 'browser/chrome/browser/preferences/sync.dtd:engine.logins.label',
+    'browser/chrome/browser/preferences/sync.dtd:engine.prefs.accesskey'        => 'browser/chrome/browser/preferences/sync.dtd:engine.prefs.label',
+    'browser/chrome/browser/preferences/sync.dtd:engine.addons.accesskey'       => 'browser/chrome/browser/preferences/sync.dtd:engine.addons.label',
+    'browser/chrome/browser/preferences/sync.dtd:engine.addresses.accesskey'    => 'browser/chrome/browser/preferences/sync.dtd:engine.addresses.label',
+    'browser/chrome/browser/preferences/sync.dtd:engine.creditcards.accesskey'  => 'browser/chrome/browser/preferences/sync.dtd:engine.creditcards.label',
 ];
 
 $ak_results = [];


### PR DESCRIPTION
These access keys have been added in [bug 1395453](https://bugzilla.mozilla.org/show_bug.cgi?id=1395453) ([changeset](https://hg.mozilla.org/l10n/gecko-strings/rev/743121cc47e3)) and I have noticed [FP for `engine.creditcards.accesskey`](https://transvision.mozfr.org/accesskeys/?locale=cs&repo=gecko_strings) today. Adding them all to avoid potential more FPs for other locales or in future.

Btw. in case there is a change in any of the IDs on both sides of the mapping, is there some reporting that the mapping is not valid? In general the approach of known mappings won't scale indefinitely and this can at least help to maintain the existing ones.