### PR TITLE
Improve FTL support (display, variables)

### DIFF
--- a/app/classes/Transvision/AnalyseStrings.php
+++ b/app/classes/Transvision/AnalyseStrings.php
@@ -47,7 +47,7 @@ class AnalyseStrings
 
         $patterns = [
             'dtd'        => '/&([A-Za-z0-9\.]+);/',                        // &foobar;
-            'ftl'        => '/\{\s*(\$[A-Za-z0-9_]+)\s*\}/u',              // { $foobar } Used in FTL files
+            'ftl'        => '/(?<!\{)\{\s*([\$|-]?[A-Za-z0-9_-]+)\s*\}/u',  // { $foo }, { foo }, { -foo } Used in FTL files
             'ios'        => '/(%(?:[0-9]+\$){0,1}@)/i',                    // %@, but also %1$@, %2$@, etc.
             'l10njs'     => '/\{\{\s*([A-Za-z0-9_]+)\s*\}\}/u',            // {{foobar2}} Used in Loop and PDFViewer
             'printf'     => '/(%(?:[0-9]+\$){0,1}(?:[0-9].){0,1}([sS]))/', // %1$S or %S. %1$0.S and %0.S are valid too

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -428,6 +428,13 @@ class ShowResults
                 $transliterate_string_id = 'transliterate_' . $string_id;
             }
 
+            // Check if it's an FTL expression before modifying the original string
+            if (strpos($key, '.ftl:') !== false && strpos($source_string, ') ->') !== false) {
+                $string_class = 'string ftl_string';
+            } else {
+                $string_class = 'string';
+            }
+
             foreach ($search_terms as $search_term) {
                 $source_string = Strings::markString($search_term, $source_string);
                 $target_string = Strings::markString($search_term, $target_string);
@@ -527,7 +534,7 @@ class ShowResults
                 $extra_column_rows = "
                 <td dir='{$direction3}' lang='{$locale3}'>
                     <span class='celltitle'>{$locale3}</span>
-                    <div class='string' id='{$clipboard_target_string2}'>{$target_string2}</div>
+                    <div class='{$string_class}' id='{$clipboard_target_string2}'>{$target_string2}</div>
                     <div dir='ltr' class='result_meta_link'>
                       <a class='source_link' href='{$locale3_path}'>
                         &lt;source&gt;
@@ -542,6 +549,7 @@ class ShowResults
             } else {
                 $extra_column_rows = '';
             }
+
             $table .= "
                 <tr class='{$component} {$search_id}'>
                   <td>
@@ -554,9 +562,7 @@ class ShowResults
                   </td>
                   <td dir='{$direction1}' lang='{$locale1}'>
                     <span class='celltitle'>{$locale1}</span>
-                    <div class='string'>
-                      {$source_string}
-                    </div>
+                    <div class='{$string_class}'>{$source_string}</div>
                     <div dir='ltr' class='result_meta_link'>
                       <a class='source_link' href='{$locale1_path}'>
                         &lt;source&gt;
@@ -567,9 +573,9 @@ class ShowResults
 
                   <td dir='{$direction2}' lang='{$locale2}'>
                     <span class='celltitle'>{$locale2}</span>
-                    <div class='string' id='{$regular_string_id}'>{$target_string}</div>";
+                    <div class='{$string_class}' id='{$regular_string_id}'>{$target_string}</div>";
             if ($transliterate) {
-                $table .= "<div class='string toggle' id='{$transliterate_string_id}' style='display: none;'>{$transliterated_string}</div>";
+                $table .= "<div class='{$string_class} toggle' id='{$transliterate_string_id}' style='display: none;'>{$transliterated_string}</div>";
             }
             $table .= "
                     <div dir='ltr' class='result_meta_link'>

--- a/app/classes/Transvision/ShowResults.php
+++ b/app/classes/Transvision/ShowResults.php
@@ -306,6 +306,7 @@ class ShowResults
                 case 'chat':
                 case 'editor':
                 case 'mail':
+                case 'other-licenses':
                     $project_name = 'thunderbird';
                     break;
                 case 'mobile':

--- a/app/scripts/setup.sh
+++ b/app/scripts/setup.sh
@@ -25,7 +25,7 @@ function echogreen() {
 
 function setupExternalLibraries() {
     # Check out or update compare-locales library
-    version="RELEASE_2_5_1"
+    version="RELEASE_2_7_0"
     if [ ! -d $libraries/compare-locales/.hg ]
     then
         echogreen "Checking out compare-locales in $libraries"
@@ -41,7 +41,7 @@ function setupExternalLibraries() {
     fi
 
     # Check out or update python-fluent library
-    version="0.4.4"
+    version="0.6.2"
     if [ ! -d $libraries/python-fluent/.git ]
     then
         echogreen "Checking out the python-fluent library in $libraries"

--- a/app/scripts/tmx/tmx_products.py
+++ b/app/scripts/tmx/tmx_products.py
@@ -33,7 +33,7 @@ else:
 # Import Fluent Python library
 import_library(
     libraries_path, 'git', 'python-fluent',
-    'https://github.com/projectfluent/python-fluent', '0.4.4')
+    'https://github.com/projectfluent/python-fluent', '0.6.2')
 try:
     import fluent.syntax
 except ImportError as e:
@@ -44,7 +44,7 @@ except ImportError as e:
 # Import compare-locales
 import_library(
     libraries_path, 'hg', 'compare-locales',
-    'https://hg.mozilla.org/l10n/compare-locales', 'RELEASE_2_5_1')
+    'https://hg.mozilla.org/l10n/compare-locales', 'RELEASE_2_7_0')
 try:
     from compare_locales import parser
 except ImportError as e:

--- a/app/views/results_entities.php
+++ b/app/views/results_entities.php
@@ -29,11 +29,17 @@ foreach ($entities as $entity) {
                                 ? $tmx_target[$entity]
                                 : '@@missing@@';
     // Escape strings for HTML display
-    $bz_target_string = $target_string = Utils::secureText($unescaped_target_string);
+    $bz_target_string = $target_string = htmlspecialchars($unescaped_target_string);
+
+    if (strpos($entity, '.ftl:') !== false && strpos($tmx_source[$entity], ') ->') !== false) {
+        $string_class = 'string ftl_string';
+    } else {
+        $string_class = 'string';
+    }
 
     // Highlight special characters only after strings have been escaped
     $target_string = Strings::highlightSpecial($target_string);
-    $source_string = Strings::highlightSpecial(Utils::secureText($tmx_source[$entity]));
+    $source_string = Strings::highlightSpecial(htmlspecialchars($tmx_source[$entity]));
 
     $clipboard_target_string = 'clip_' . md5($target_string);
     $string_id = md5($entity . mt_rand());
@@ -47,7 +53,7 @@ foreach ($entities as $entity) {
     $transliterate = $locale == 'sr' && ! $extra_locale && $target_string && $target_string != '@@missing@@';
 
     if ($transliterate) {
-        $transliterated_string = Utils::secureText($tmx_target[$entity]);
+        $transliterated_string = htmlspecialchars($tmx_target[$entity]);
         $transliterated_string = ShowResults::getTransliteratedString(urlencode($transliterated_string), 'sr-Cyrl');
         $transliterated_string = Strings::highlightSpecial($transliterated_string);
         $transliterate_string_id = 'transliterate_' . $string_id;
@@ -59,7 +65,7 @@ foreach ($entities as $entity) {
     // 3locales view
     if ($extra_locale) {
         $bz_target_string2 = $target_string2 = isset($tmx_target2[$entity])
-                                                    ? Utils::secureText($tmx_target2[$entity])
+                                                    ? htmlspecialchars($tmx_target2[$entity])
                                                     : '';
         // Highlight special characters only after strings have been escaped
         $target_string2 = Strings::highlightSpecial($target_string2);
@@ -92,7 +98,7 @@ foreach ($entities as $entity) {
         $extra_column_rows = "
     <td dir='{$direction3}'>
       <span class='celltitle'>{$locale2}</span>
-      <div class='string' id='{$clipboard_target_string2}'>{$target_string2}</div>
+      <div class='{$string_class}' id='{$clipboard_target_string2}'>{$target_string2}</div>
       <div dir='ltr' class='result_meta_link'>
         <a class='source_link' href='{$path_locale3}'>&lt;source&gt;</a>
         {$file_bug}
@@ -175,7 +181,7 @@ foreach ($entities as $entity) {
     </td>
     <td dir='{$direction1}'>
       <span class='celltitle'>{$source_locale}</span>
-      <div class='string'>{$source_string}</div>
+      <div class='{$string_class}'>{$source_string}</div>
       <div dir='ltr' class='result_meta_link'>
         <a class='source_link' href='{$path_locale1}'>&lt;source&gt;</a>
         {$meta_source}
@@ -183,7 +189,7 @@ foreach ($entities as $entity) {
     </td>
     <td dir='{$direction2}'>
       <span class='celltitle'>{$locale}</span>
-      <div class='string' id='{$regular_string_id}'>{$target_string}</div>";
+      <div class='{$string_class}' id='{$regular_string_id}'>{$target_string}</div>";
     if ($transliterate) {
         $table .= "<div class='string toggle' id='{$transliterate_string_id}' style='display: none;'>{$transliterated_string}</div>";
     }

--- a/tests/units/Transvision/AnalyseStrings.php
+++ b/tests/units/Transvision/AnalyseStrings.php
@@ -141,7 +141,7 @@ class AnalyseStrings extends atoum\test
             ],
             [
                 // {{n}} vs {{ n }}, changed order (not an error)
-                ['browser:foobar14' => '{{ n}} more and {{ name }}'],
+                ['browser:foobar14' => '{{n}} more and {{ name }}'],
                 ['browser:foobar14' => '{{name}} et {{n}} autre'],
                 'gecko_strings',
                 [],
@@ -162,6 +162,22 @@ class AnalyseStrings extends atoum\test
                 'gecko_strings',
                 [],
                 ['browser:foobar16'],
+            ],
+            [
+                // Missing message reference for FTL
+                ['browser:foobar16b' => '{ other-message } installed'],
+                ['browser:foobar16b' => 'installato'],
+                'gecko_strings',
+                [],
+                ['browser:foobar16b'],
+            ],
+            [
+                // Missing term reference for FTL
+                ['browser:foobar16c' => '{ -brand-name } installed'],
+                ['browser:foobar16c' => 'installato'],
+                'gecko_strings',
+                [],
+                ['browser:foobar16c'],
             ],
             [
                 // Mispelled variable

--- a/tests/units/Transvision/ShowResults.php
+++ b/tests/units/Transvision/ShowResults.php
@@ -422,6 +422,14 @@ class ShowResults extends atoum\test
             ],
             [
                 'pontoon',
+                'gecko_strings',
+                'other-licenses/branding/thunderbird/brand.dtd:trademarkInfo.part1',
+                'test',
+                'bg',
+                "&nbsp;<a class='edit_link' target='_blank' href='https://pontoon.mozilla.org/bg/thunderbird/other-licenses/branding/thunderbird/brand.dtd?search=trademarkInfo.part1'>&lt;edit in Pontoon&gt;</a>",
+            ],
+            [
+                'pontoon',
                 'mozilla_org',
                 'mozilla_org/firefox/android/index.lang:4e0bc9d4',
                 'test',

--- a/web/style/transvision.css
+++ b/web/style/transvision.css
@@ -377,6 +377,10 @@ td {
     display: none;
 }
 
+.ftl_string {
+    white-space: pre-wrap;
+}
+
 td a.onestring_search {
     display: block;
     margin: 0 auto;


### PR DESCRIPTION
* Add support for Fluent 0.6 syntax (python-fluent 0.6.2, compare-locales 2.7.0)
* Display expressions as `whitespace: pre-wrap`
![schermata 2018-02-08 alle 15 55 31](https://user-images.githubusercontent.com/3644868/35979388-84010866-0ce8-11e8-9b72-a0f07c77f1ee.png)
* Support more variable formats:
    * `{ $foo }`: external argument (already supported)
    * `{ foo }`: message reference
    * `{ -foo }`: term reference

Also fixes #935.

