### PR TITLE
(fix #956) Stop overwriting search result when locales are the same

### DIFF
--- a/app/models/mainsearch_strings.php
+++ b/app/models/mainsearch_strings.php
@@ -32,7 +32,6 @@ array_splice($locale2_strings, $limit_results);
 
 $searches = [
     $source_locale => $locale1_strings,
-    $locale        => $locale2_strings,
 ];
 $data = [$tmx_source, $tmx_target];
 unset($tmx_source, $tmx_target);


### PR DESCRIPTION
If there are results only in entities:
1. We search for strings in both source and target, with no results.
2. We search for entities in the target language, finding results.

Then we set `$searches` for both source and target locale, but the target locale is empty, and this results in an empty array.

A few lines later we already had a check to only store target results when the 2 locales are different, but it was useless.