### PR TITLE
Fix false positive in FTL variables caused by properties checks

### DIFF
--- a/app/classes/Transvision/AnalyseStrings.php
+++ b/app/classes/Transvision/AnalyseStrings.php
@@ -57,7 +57,7 @@ class AnalyseStrings
             // %1$S or %S. %1$0.S and %0.S are valid too
             'printf'      => '/(%(?:[0-9]+\$){0,1}(?:[0-9].){0,1}([sS]))/',
             // $BrandShortName, but not "My%1$SFeeds-%2$S.opml" or "{ $brandShortName }"
-            'properties'  => '/(?<!%[0-9]|\{\s)(\$[A-Za-z0-9\.]+)\b/',
+            'properties'  => '/(?<!%[0-9]|\{\s|\{)(\$[A-Za-z0-9\.]+)\b/',
             // %1$s or %s. %d
             'xml_android' => '/(%(?:[0-9]+\$){0,1}([sd]))/',
         ];

--- a/tests/units/Transvision/AnalyseStrings.php
+++ b/tests/units/Transvision/AnalyseStrings.php
@@ -164,6 +164,22 @@ class AnalyseStrings extends atoum\test
                 ['browser:foobar16'],
             ],
             [
+                // Difference spacing in variable for FTL (not an error)
+                ['browser:foobar16a1' => '{ $brandname } installed'],
+                ['browser:foobar16a1' => '{$brandname} installato'],
+                'gecko_strings',
+                [],
+                [],
+            ],
+            [
+                // Difference spacing in variable for FTL (not an error)
+                ['browser:foobar16a2' => '{$brandname} installed'],
+                ['browser:foobar16a2' => '{ $brandname } installato'],
+                'gecko_strings',
+                [],
+                [],
+            ],
+            [
                 // Missing message reference for FTL
                 ['browser:foobar16b' => '{ other-message } installed'],
                 ['browser:foobar16b' => 'installato'],


### PR DESCRIPTION
'{ $brandname } installed` was not detected by properties check (correctly), but `{$brandname} installed` was, causing false positives in FTL.

Sadly, it's not possible to use quantifier in negative lookahead.

A structural improvement would be to limit checks to specific file extensions.