### PR TITLE
Log when parsed url has no path

### DIFF
--- a/app/inc/router.php
+++ b/app/inc/router.php
@@ -21,6 +21,12 @@ if ($url === false) {
     $url['path'] = '404';
 }
 
+// Log if the 'path' is not set set.
+if (! isset($url['path'])) {
+    error_log('app/inc/router.php: ' . $_SERVER['REQUEST_URI'] . ' is not parsable (no path).');
+    $url['path'] = '404';
+}
+
 $file = pathinfo($url['path']);
 
 // Real files and folders don't get pre-processed


### PR DESCRIPTION
Found a warning in my logs, pretty sure it's some script kiddie trying to break the server.

```
PHP message: PHP Notice:  Undefined index: path in app/inc/router.php on line 27
PHP message: PHP Notice:  Undefined index: path in inc/router.php on line 28" while reading response header from upstream, client: IP, server: transvision.flod.org, request: "GET //xmlrpc.php?rsd HTTP/1.1", upstream: "fastcgi://unix:/run/php/php7.2-fpm.sock:", host: "transvision.flod.org"
```