### PR TITLE
Fix errors with unlocalized-all

### DIFF
--- a/app/models/unlocalized_words_all.php
+++ b/app/models/unlocalized_words_all.php
@@ -74,18 +74,18 @@ function filter_strings($locale, $repo, $strings_reference)
     unlocalized-all.
 */
 switch ($page) {
-    case 'unlocalized-all':
-        $cache_id = $repo . $page . 'unlocalized_words_all';
+    case 'unlocalized_all':
+        $cache_id = "{$repo}|{$page}|unlocalized_words_all";
         break;
     default:
-        $cache_id = $repo . $page . $locale . 'unlocalized_words';
+        $cache_id = "{$repo}|{$page}|{$locale}|unlocalized_words";
 }
 
 if (! $unlocalized_words = Cache::getKey($cache_id)) {
     $unlocalized_words = [];
     foreach ($all_locales as $lang) {
         // Load locale strings.
-        $cache_id2 = $repo . $page . $lang . 'unlocalized_words';
+        $cache_id2 = "{$repo}|{$page}|{$lang}|unlocalized_words";
         if (! $strings = Cache::getKey($cache_id2)) {
             $strings = filter_strings($lang, $repo, $strings_reference);
             Cache::setKey($cache_id2, $strings);

--- a/app/views/unlocalized_words_all.php
+++ b/app/views/unlocalized_words_all.php
@@ -28,15 +28,7 @@ include __DIR__ . '/simplesearchform.php';
    </thead>
    <tbody>
 <?php foreach ($unlocalized_words as $english_term => $locales) :
-if (empty($locales) || is_string($locales)) {
-  // TODO: remove logs, see https://github.com/mozfr/transvision/issues/1010
-  if (is_string($locales)) {
-    error_log("unlocalized-all: locales is a string for \"{$english_term}\". locales var: {$locales}.");
-    error_log("unlocalized-all: cache-id is {$cache_id}.");
-  }
-  if (empty($locales)) {
-    error_log("unlocalized-all: empty list of locales for {$english_term}, creating empty array.");
-  }
+if (empty($locales)) {
   $locales = [];
 }
 ?>


### PR DESCRIPTION
Using more readable IDs for the cache, but the problem is with the selector (for `/unlocalized-all`, `$page` is `unlocalized_all` with an underscore 🤦🏼 )